### PR TITLE
Adjust production schedule to 21:15 UTC

### DIFF
--- a/.github/workflows/production_automation.yml
+++ b/.github/workflows/production_automation.yml
@@ -2,8 +2,8 @@ name: Production Market Data Automation
 
 on:
   schedule:
-    # Runs Monday through Friday at 10 PM Berlin time (UTC+1, so 21:00 UTC)
-    - cron: '0 21 * * 1-5'
+    # Runs Monday through Friday at 10:15 PM Berlin time (UTC+1, so 21:15 UTC)
+    - cron: '15 21 * * 1-5'
   workflow_dispatch:  # Allows manual trigger
 
 permissions:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates the GitHub Actions schedule to run weekdays at 21:15 UTC instead of 21:00 UTC.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 636b56f396d61b6698e9d45d62d3abcfffea4d65. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->