### PR TITLE
Fix Airflow DAG path for load_symbols script

### DIFF
--- a/airflow/dags/market_data_update.py
+++ b/airflow/dags/market_data_update.py
@@ -38,9 +38,9 @@ with DAG(
     initialize_database = BashOperator(
         task_id="initialize_database",
         bash_command=(
-            f"cd {ANALYTICS_DIR} && "
-            "python database/init_db.py && "
-            "python database/load_symbols.py"
+            f"cd {PROJECT_ROOT} && "
+            "python analytics/database/init_db.py && "
+            "python analytics/database/load_symbols.py"
         ),
         env=env,
     )


### PR DESCRIPTION
- Change working directory from ANALYTICS_DIR to PROJECT_ROOT
- Update paths to use analytics/database/ prefix
- Fixes 'Symbols file not found' error
- Verified: All three tasks now complete successfully

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update `initialize_database` task to execute from `PROJECT_ROOT` and call `analytics/database` scripts.
> 
> - **Airflow DAG `airflow/dags/market_data_update.py`**:
>   - Update `initialize_database` Bash command to `cd` into `PROJECT_ROOT` and invoke `analytics/database/init_db.py` and `analytics/database/load_symbols.py` (replacing `ANALYTICS_DIR` and `database/...`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 00392f09ccf18d2cd4d38c2bd71dda661ea26512. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->