### PR TITLE
Remove password information from Airflow setup docs

### DIFF
--- a/analytics/docs/airflow_setup.md
+++ b/analytics/docs/airflow_setup.md
@@ -51,7 +51,7 @@ airflow/
 
 4. **Access the UI.**
    - Open <http://localhost:8080>.
-   - Log in with `admin / admin`. (Change the password after the first login.)
+   - Log in with the default credentials.
 
 ## Daily DAG
 


### PR DESCRIPTION
- Change login instruction to use 'default credentials' instead of explicit password
- Removes password from documentation for security
- Default credentials remain unchanged (admin/admin)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces hardcoded admin/admin login with generic “default credentials” in the Airflow setup guide.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e22bd45509937fd702bb541cc3429a1bf9a29ee8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->