### PR TITLE
fix: Supabase IPv6 connection failure from GitHub Actions

### DIFF
--- a/.github/workflows/production_automation.yml
+++ b/.github/workflows/production_automation.yml
@@ -15,6 +15,8 @@ jobs:
 
     env:
       DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      # Supabase requires SSL; 'require' is safe for any hosted PostgreSQL
+      DB_SSLMODE: require
       # Individual vars parsed from DATABASE_URL for dbt (see "Parse DB vars" step)
       DB_HOST: ""
       DB_PORT: ""

--- a/dbt/profiles.yml
+++ b/dbt/profiles.yml
@@ -9,4 +9,6 @@ etf_analytics:
       dbname: "{{ env_var('DB_NAME', 'etf_db') }}"
       schema: public
       threads: 4
+      # require SSL for hosted DBs (Supabase/Neon); 'prefer' works for local Docker
+      sslmode: "{{ env_var('DB_SSLMODE', 'prefer') }}"
   target: dev


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

GitHub Actions runners have no IPv6 connectivity. Supabase's direct connection host (`db.[ref].supabase.co`) resolves to an IPv6 address, causing every step to fail with `Network is unreachable`.

## Fix

**Code changes:**
- `dbt/profiles.yml` — add `sslmode` driven by `DB_SSLMODE` env var (`prefer` locally, `require` in CI)
- `production_automation.yml` — set `DB_SSLMODE=require` for all CI runs

**Required user action (one time):**
Update the `DATABASE_URL` GitHub secret to the **Supabase Session Pooler URL** (IPv4):
- Supabase → Project Settings → Database → Connection pooling → **Session** mode → copy URL
- GitHub repo → Settings → Secrets → update `DATABASE_URL`

The Session Pooler URL resolves to `aws-0-[region].pooler.supabase.com` (IPv4) and works from GitHub Actions.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-64fcc1db-6cef-4360-a6e6-889b90a77a1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-64fcc1db-6cef-4360-a6e6-889b90a77a1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

