### PR TITLE
feat: DE portfolio pipeline — Airflow + dbt showcase

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -1,14 +1,12 @@
 name: Deploy static site to Pages
 
+# The landing page (website/index.html) is a static redirect to the Metabase
+# dashboard. No Python data generation is needed — just deploy the HTML/CSS/JS.
+
 on:
   push:
     branches: ["main"]
   workflow_dispatch:
-  workflow_run:
-    workflows: ["Production Market Data Automation"]
-    types:
-      - completed
-    branches: ["main"]
 
 permissions:
   contents: read
@@ -21,8 +19,6 @@ concurrency:
 
 jobs:
   deploy:
-    # Always run on push, or if production automation completed successfully
-    if: github.event_name == 'push' || (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
@@ -30,47 +26,15 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.10'
-      
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
-      
-      - name: Debug - Check project structure
-        run: |
-          echo "Current directory: $(pwd)"
-          echo "Project structure:"
-          ls -la
-          echo "Analytics directory:"
-          ls -la analytics/
-          echo "Database directory:"
-          ls -la analytics/database/
-      
-      - name: Generate website data
-        run: |
-          echo "Generating website data files..."
-          python -m analytics.database.init_db || echo "Database already exists"
-          python -m analytics.database.load_symbols || echo "Symbols already loaded"
-          python -m analytics.etl.market_data_fetcher || echo "Market data fetch completed"
-          python -m analytics.etl.data_exporter || echo "Data export completed"
-          echo "Checking generated files:"
-          ls -la website/data/
-          echo "Verifying symbols.json contains all ETFs:"
-          cat website/data/symbols.json
-      
+
       - name: Setup Pages
         uses: actions/configure-pages@v4
-      
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
           path: website
-      
+
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -1,115 +1,177 @@
-# ETF Analytics Dashboard — v1
+# ETF Analytics — End-to-End Data Engineering Pipeline
 
-ETF analytics platform with automated market data updates, dbt transformations,
-and a Metabase dashboard built by AI.
-
-## Stack
-
-| Layer | Tool |
-|---|---|
-| Data fetch | Python + `yfinance` |
-| Database | PostgreSQL 16 (Docker) |
-| Transformations | dbt Core |
-| Visualization | Metabase OSS (Docker) |
-| Orchestration | GitHub Actions |
-
-## Supported ETFs
-
-| Ticker | Name | Currency |
-|---|---|---|
-| VOO | Vanguard S&P 500 ETF | USD |
-| VTI | Vanguard Total Stock Market ETF | USD |
-| QQQ | Invesco QQQ Trust | USD |
-| VUAA.L | Vanguard S&P 500 UCITS ETF | USD |
-| CNDX.L | iShares NASDAQ 100 UCITS ETF | GBP |
+A production-style Data Engineering project tracking 5 ETFs (VOO, VTI, QQQ, VUAA.L, CNDX.L).
+Demonstrates a complete, automated ELT pipeline from raw market data to live dashboards.
 
 ---
 
-## Quick Start (Docker Desktop required)
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                          ORCHESTRATION                               │
+│                                                                      │
+│   Apache Airflow  ──────────────────────────────────────────────    │
+│   (local Docker)       DAG: etf_market_data_pipeline                │
+│                                                                      │
+│   ┌──────────────┐  ┌──────────────┐  ┌──────────────┐  ┌───────┐  │
+│   │ Extract&Load │→ │  Transform   │→ │   Quality    │→ │ Viz   │  │
+│   │              │  │              │  │              │  │       │  │
+│   │ init_db      │  │ dbt staging  │  │ dbt test     │  │ sync  │  │
+│   │ load_symbols │  │ dbt interm.  │  │ dbt source   │  │ Meta- │  │
+│   │ fetch_data   │  │ dbt marts    │  │   freshness  │  │ base  │  │
+│   └──────────────┘  └──────────────┘  └──────────────┘  └───────┘  │
+└───────────┬─────────────────┬────────────────────────────────┬──────┘
+            │                 │                                │
+            ▼                 ▼                                ▼
+  ┌──────────────────┐  ┌───────────────────────┐  ┌──────────────────┐
+  │   Yahoo Finance  │  │      PostgreSQL        │  │    Metabase      │
+  │   (yfinance)     │  │  (Supabase free tier)  │  │ (Oracle Cloud    │
+  │                  │  │                        │  │  Always Free VM) │
+  │  OHLCV prices    │  │  Raw tables  (Python)  │  │                  │
+  │  FX rates        │  │  Mart tables (dbt)     │  │  Live dashboard  │
+  └──────────────────┘  └───────────────────────┘  │  auto-refreshed  │
+                                                    └──────────────────┘
+
+  GitHub Actions → daily schedule (production, no Airflow server needed)
+```
+
+---
+
+## Tech Stack
+
+| Layer | Tool | Purpose |
+|---|---|---|
+| **Orchestration** | Apache Airflow 2.9 | DAG scheduling, task dependencies, retries |
+| **Extract & Load** | Python + yfinance | Incremental fetch from Yahoo Finance → PostgreSQL |
+| **Transform** | dbt Core 1.8 | Staging → Intermediate → Mart models |
+| **Warehouse** | PostgreSQL 16 | Single source of truth (Supabase in production) |
+| **Visualization** | Metabase OSS | Live dashboards built via MCP + AI |
+| **CI / CD** | GitHub Actions | Tests on every PR; daily pipeline run in production |
+| **Infrastructure** | Docker Compose | Local dev (Airflow + PostgreSQL + Metabase) |
+
+---
+
+## Pipeline — What Happens Every Weekday Night
+
+```
+21:15 UTC  Airflow scheduler triggers etf_market_data_pipeline
+           │
+           ├── extract_load
+           │    ├── init_database      ensure schema is current (idempotent)
+           │    ├── load_symbols       reload ETF reference data from CSV
+           │    └── fetch_market_data  incremental OHLCV fetch from Yahoo Finance
+           │
+           ├── transform              (runs only if extract_load succeeds)
+           │    ├── dbt_run_staging        stg_etf_data, stg_currency_rates
+           │    ├── dbt_run_intermediate   int_etf_eur  (EUR fallback logic)
+           │    └── dbt_run_marts          mart_price_history
+           │                               mart_52week_metrics
+           │                               mart_entry_thresholds
+           │
+           ├── quality                (test + freshness run in parallel)
+           │    ├── dbt_test               schema tests: not_null, unique
+           │    └── dbt_source_freshness   SLA: warn >12 h, error >24 h
+           │
+           └── visualize              (skipped when METABASE_URL not set)
+                └── sync_metabase      Metabase schema resync via REST API
+```
+
+---
+
+## dbt Data Models
+
+```
+dbt/models/
+├── staging/                    materialized as VIEWS
+│   ├── sources.yml             raw source definitions + freshness SLA
+│   ├── schema.yml              staging model + column documentation
+│   ├── stg_etf_data.sql        clean OHLCV joined with ETF metadata
+│   └── stg_currency_rates.sql  validated historical FX rates
+│
+├── intermediate/               materialized as VIEWS
+│   └── int_etf_eur.sql         guarantees EUR columns on every row
+│                               (ETL value → same-day rate → latest rate)
+│
+└── marts/                      materialized as TABLES (for fast Metabase queries)
+    ├── schema.yml              full column documentation for all marts
+    ├── mart_price_history.sql  daily OHLCV + EUR + daily Δ% + 7-day MA
+    ├── mart_52week_metrics.sql latest 52w high/low + distance from high/low
+    └── mart_entry_thresholds.sql 5–30% entry levels (long format, 30 rows total)
+```
+
+---
+
+## Tracked ETFs
+
+| Ticker | Name | Exchange | Currency |
+|---|---|---|---|
+| VOO | Vanguard S&P 500 ETF | NYSE | USD |
+| VTI | Vanguard Total Stock Market ETF | NYSE | USD |
+| QQQ | Invesco QQQ Trust | NASDAQ | USD |
+| VUAA.L | Vanguard S&P 500 UCITS ETF | LSE | USD |
+| CNDX.L | iShares NASDAQ 100 UCITS ETF | LSE | GBP |
+
+---
+
+## Local Development — Quick Start
+
+**Requirements:** Docker Desktop
 
 ```bash
 # 1. Clone and configure
-git clone <repository-url>
+git clone https://github.com/anyarlene/stock-market.git
 cd stock-market
-cp .env.example .env          # defaults work for local Docker
+cp .env.example .env                      # edit DB creds if needed
 
 # 2. Start PostgreSQL + Metabase
 docker compose up -d
 
-# 3. Install Python dependencies
-pip install -r requirements.txt
-
-# 4. Initialize DB, load symbols, fetch data
-cd analytics
-PYTHONPATH=.. python database/init_db.py
-PYTHONPATH=.. python database/load_symbols.py
-cd ..
-PYTHONPATH=. python analytics/enhanced_workflow.py --step full
-
-# 5. Run dbt transformations
-cd dbt
-dbt run --profiles-dir .
+# 3. Start Airflow (builds custom image with dbt + psycopg2)
+cd airflow
+cp env.example .env                       # edit DATABASE_URL if needed
+docker compose up -d --build
 cd ..
 
-# 6. Open Metabase at http://localhost:3000
+# 4. Open Airflow at http://localhost:8080  (admin / admin)
+#    Unpause the  etf_market_data_pipeline  DAG and trigger a run.
+
+# 5. Open Metabase at http://localhost:3000
+#    Connect it to PostgreSQL (host: host.docker.internal, port: 5432)
+#    Build the dashboard — see analytics/docs/metabase_setup.md
 ```
 
-For Metabase setup, MCP connection, and AI-assisted dashboard build:
-→ See `analytics/docs/metabase_setup.md`
+### Run dbt manually (without Airflow)
 
----
-
-## dbt Models
-
-```
-dbt/models/
-├── staging/
-│   ├── stg_etf_data.sql          ← cleans raw price + symbol join
-│   └── stg_currency_rates.sql    ← cleans FX rate cache
-├── intermediate/
-│   └── int_etf_eur.sql           ← ensures all rows have EUR prices
-└── marts/
-    ├── mart_price_history.sql    ← daily OHLCV + EUR + derived metrics
-    ├── mart_52week_metrics.sql   ← latest 52-week high/low per ETF
-    └── mart_entry_thresholds.sql ← 5–30% entry levels (long format)
-```
-
-Run transformations:
 ```bash
-cd dbt && dbt run --profiles-dir . && dbt test --profiles-dir .
+pip install -r requirements.txt
+cp .env.example .env && source .env       # or set DATABASE_URL in your shell
+
+cd dbt
+dbt deps                                  # install dbt_utils
+dbt run --profiles-dir .                  # build all models
+dbt test --profiles-dir .                 # run all tests
+dbt source freshness --profiles-dir .     # check SLA compliance
+dbt docs generate --profiles-dir .        # generate data catalog
+dbt docs serve --profiles-dir .           # serve at http://localhost:8080
 ```
 
 ---
 
-## Automation
+## Production — Zero Daily Work
 
-### Production — zero daily work, access from anywhere
-
-| Piece | Service | Cost |
+| Service | Provider | Cost |
 |---|---|---|
-| Database | [Supabase](https://supabase.com) free tier | Free |
-| Daily data update | GitHub Actions (already configured) | Free |
-| Dashboard | Oracle Cloud Always Free VM | Free |
+| PostgreSQL | [Supabase](https://supabase.com) free tier (500 MB) | Free |
+| Daily pipeline | GitHub Actions (schedule trigger) | Free |
+| Metabase dashboard | [Oracle Cloud Always Free](https://www.oracle.com/cloud/free/) ARM VM | Free |
 
 **After one-time setup:** open `http://<oracle-ip>:3000` from any browser.
-Data refreshes automatically every weekday. No local Docker. No manual runs.
+Data refreshes every weekday night automatically via GitHub Actions.
 
-→ Full setup guide: `analytics/docs/metabase_setup.md` (Production Setup section)
+Required GitHub secret: `DATABASE_URL` (Supabase Session Pooler URL — IPv4).
 
-### GitHub Actions schedule
-
-- **When**: Weekdays at 21:15 UTC
-- **What**: ETL fetch → PostgreSQL insert → `dbt run` → `dbt test`
-- **Required secret**: `DATABASE_URL` (Supabase connection string) in repo Settings → Secrets
-
-### Development Workflow
-
-```bash
-git checkout -b cursor/<feature-name>-7a1c
-# make changes
-git push -u origin <branch>
-# open PR → merge to main
-```
+→ Full setup guide: `analytics/docs/metabase_setup.md`
 
 ---
 
@@ -117,26 +179,41 @@ git push -u origin <branch>
 
 ```
 stock-market/
+├── airflow/
+│   ├── Dockerfile                  custom image with dbt + psycopg2
+│   ├── docker-compose.yaml         Airflow stack (scheduler, webserver, triggerer)
+│   ├── env.example                 Airflow env vars template
+│   ├── requirements.txt            Airflow extra packages
+│   └── dags/
+│       ├── etf_pipeline.py         ★ main showcase DAG (ELT + dbt + Metabase)
+│       └── market_data_update.py   legacy DAG (kept for reference)
+│
 ├── analytics/
-│   ├── enhanced_workflow.py        # ETL orchestrator
-│   ├── database/                   # DB manager + schema (PostgreSQL)
-│   ├── etl/                        # Fetchers + currency ETL
-│   ├── utils/                      # Currency converter
-│   └── docs/                       # Setup + Metabase guide
+│   ├── enhanced_workflow.py        ETL orchestrator (used by Airflow DAG)
+│   ├── database/                   schema, DB manager, symbol loader
+│   ├── etl/                        fetcher, currency converter
+│   ├── utils/                      FX converter, validators
+│   └── docs/                       setup guides, Metabase MCP guide
+│
 ├── dbt/
-│   ├── dbt_project.yml
-│   ├── profiles.yml
+│   ├── dbt_project.yml             project config (staging/int = view, marts = table)
+│   ├── profiles.yml                connection via env vars
+│   ├── packages.yml                dbt_utils
 │   └── models/
-│       ├── staging/
-│       ├── intermediate/
-│       └── marts/
-├── website/
-│   ├── index.html                  # Legacy chart view (kept)
-│   └── archived/                   # Investment Strategy Planner (archived)
+│       ├── staging/                sources.yml (with freshness), stg_* models
+│       ├── intermediate/           int_etf_eur
+│       └── marts/                  mart_price_history, mart_52week_metrics,
+│                                   mart_entry_thresholds  (+ full schema docs)
+│
 ├── .github/workflows/
-├── docker-compose.yml
-├── .env.example
-└── requirements.txt
+│   ├── production_automation.yml   daily ETL + dbt (Mon–Fri 21:15 UTC)
+│   ├── test_automation.yml         CI on every PR (PostgreSQL service container)
+│   └── deploy-website.yml          static landing page → GitHub Pages
+│
+├── docker-compose.yml              local: PostgreSQL + Metabase
+├── docker-compose.prod.yml         production: Metabase only (DB on Supabase)
+├── .env.example                    environment variable template
+└── requirements.txt                Python dependencies
 ```
 
 ---
@@ -145,17 +222,24 @@ stock-market/
 
 | File | Topic |
 |---|---|
-| `analytics/docs/metabase_setup.md` | Full Metabase + MCP + AI dashboard guide |
-| `analytics/docs/stock-market-v1.md` | v1 plan and architecture overview |
-| `analytics/docs/setup.md` | Initial environment setup |
-| `analytics/docs/automation_setup.md` | GitHub Actions configuration |
+| `analytics/docs/metabase_setup.md` | Metabase local + production (Oracle + Supabase) |
+| `analytics/docs/stock-market-v1.md` | v1 architecture decisions |
+| `analytics/docs/airflow_setup.md` | Airflow local setup guide |
 
 ---
 
-## Adding New ETFs
+## Adding a New ETF
 
-1. Edit `analytics/database/reference/symbols.csv`
-2. Run `python analytics/database/load_symbols.py`
-3. Run `python analytics/enhanced_workflow.py --step incremental`
-4. Run `cd dbt && dbt run --profiles-dir .`
-5. Refresh Metabase metadata sync (Admin > Databases > Sync)
+```bash
+# 1. Add a row to analytics/database/reference/symbols.csv
+# 2. Reload symbols
+python analytics/database/load_symbols.py
+
+# 3. Fetch historical data
+PYTHONPATH=. python analytics/enhanced_workflow.py --step full
+
+# 4. Rebuild dbt models
+cd dbt && dbt run --profiles-dir . && dbt test --profiles-dir .
+
+# 5. Sync Metabase (Admin → Databases → Sync schema)
+```

--- a/airflow/Dockerfile
+++ b/airflow/Dockerfile
@@ -1,7 +1,6 @@
-FROM ${AIRFLOW_IMAGE_NAME:-apache/airflow:2.9.1}
+FROM apache/airflow:2.9.1
 
 USER airflow
 
 COPY requirements.txt /tmp/airflow-requirements.txt
 RUN pip install --no-cache-dir -r /tmp/airflow-requirements.txt
-

--- a/airflow/dags/etf_pipeline.py
+++ b/airflow/dags/etf_pipeline.py
@@ -1,0 +1,292 @@
+"""ETF Market Data Pipeline
+============================
+
+A production-style ELT pipeline for ETF analytics.
+
+Pipeline stages
+---------------
+1. **Extract & Load**  — fetch OHLCV prices and FX rates from Yahoo Finance
+                          and upsert them into PostgreSQL.
+2. **Transform**       — run dbt models in layer order:
+                          staging → intermediate → marts.
+3. **Quality**         — run dbt tests and check source freshness in parallel.
+4. **Visualize**       — trigger Metabase to resync schema so new mart tables
+                          are immediately visible in dashboards (optional; skipped
+                          when METABASE_URL Airflow Variable is not set).
+
+Schedule : Mon–Fri at 21:15 UTC
+Data source : Yahoo Finance (yfinance)
+Warehouse   : PostgreSQL (Supabase in production, local Docker in dev)
+Transform   : dbt Core
+Dashboards  : Metabase OSS
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timedelta
+from pathlib import Path
+
+from airflow import DAG
+from airflow.models import Variable
+from airflow.operators.bash import BashOperator
+from airflow.operators.empty import EmptyOperator
+from airflow.operators.python import PythonOperator, ShortCircuitOperator
+from airflow.utils.task_group import TaskGroup
+from airflow.utils.trigger_rule import TriggerRule
+
+# ---------------------------------------------------------------------------
+# Paths — the whole repo is mounted at /opt/airflow/project
+# ---------------------------------------------------------------------------
+PROJECT_ROOT = Path("/opt/airflow/project")
+DBT_DIR = PROJECT_ROOT / "dbt"
+
+# ---------------------------------------------------------------------------
+# Default task arguments
+# ---------------------------------------------------------------------------
+default_args = {
+    "owner": "data-engineering",
+    "depends_on_past": False,
+    "email_on_failure": False,
+    "email_on_retry": False,
+    "retries": 2,
+    "retry_delay": timedelta(minutes=5),
+}
+
+# ---------------------------------------------------------------------------
+# Helpers used by PythonOperators
+# ---------------------------------------------------------------------------
+
+def _init_database() -> None:
+    """Ensure all PostgreSQL tables exist (idempotent)."""
+    import sys
+    sys.path.insert(0, str(PROJECT_ROOT))
+    from analytics.database.db_manager import DatabaseManager
+
+    db = DatabaseManager()
+    db.initialize_database()
+
+
+def _load_symbols() -> None:
+    """Reload ETF symbols from the CSV reference file."""
+    import sys
+    sys.path.insert(0, str(PROJECT_ROOT))
+    from analytics.database.load_symbols import load_symbols
+
+    csv_path = str(PROJECT_ROOT / "analytics" / "database" / "reference" / "symbols.csv")
+    load_symbols(csv_path)
+
+
+def _fetch_market_data() -> dict:
+    """Incrementally fetch OHLCV data from Yahoo Finance and upsert into PostgreSQL.
+
+    Returns the run summary dict for downstream logging via XCom.
+    Raises RuntimeError when the overall fetch fails so Airflow marks the
+    task as failed and triggers the retry policy.
+    """
+    import sys
+    sys.path.insert(0, str(PROJECT_ROOT))
+    from analytics.etl.enhanced_market_data_fetcher import EnhancedMarketDataFetcher
+
+    fetcher = EnhancedMarketDataFetcher()
+    results = fetcher.run_incremental_update()
+
+    if not results.get("overall_success"):
+        raise RuntimeError(f"Market data fetch reported failure: {results}")
+
+    return results
+
+
+def _should_sync_metabase() -> bool:
+    """Return True when the METABASE_URL Airflow Variable is configured.
+
+    Used as a ShortCircuitOperator gate so the visualize task group is
+    silently skipped in environments where Metabase is not set up yet.
+    """
+    try:
+        url = Variable.get("METABASE_URL", default_var="")
+        return bool(url.strip())
+    except Exception:
+        return False
+
+
+def _sync_metabase() -> None:
+    """Trigger Metabase to resync its ETF database connection.
+
+    Requires two Airflow Variables to be set:
+      - METABASE_URL   : base URL of your Metabase instance
+                         e.g. http://<oracle-ip>:3000
+      - METABASE_API_KEY : admin API key created in Metabase Admin → API Keys
+
+    On success Metabase picks up any new/renamed dbt mart tables within
+    about a minute, keeping dashboards always current.
+    """
+    import requests
+
+    metabase_url = Variable.get("METABASE_URL").rstrip("/")
+    api_key = Variable.get("METABASE_API_KEY")
+    headers = {"X-API-Key": api_key, "Content-Type": "application/json"}
+
+    # Discover the ETF analytics database inside Metabase
+    resp = requests.get(f"{metabase_url}/api/database", headers=headers, timeout=30)
+    resp.raise_for_status()
+    databases = resp.json().get("data", [])
+
+    etf_db = next(
+        (d for d in databases if "etf" in d.get("name", "").lower()),
+        None,
+    )
+    if etf_db is None:
+        raise RuntimeError(
+            "No ETF database found in Metabase. "
+            "Connect it first via Admin → Databases → Add a database."
+        )
+
+    db_id = etf_db["id"]
+
+    # Trigger schema resync (picks up new tables / columns from dbt marts)
+    requests.post(f"{metabase_url}/api/database/{db_id}/sync_schema", headers=headers, timeout=30)
+    # Rescan field values (keeps filter dropdowns fresh)
+    requests.post(f"{metabase_url}/api/database/{db_id}/rescan_values", headers=headers, timeout=30)
+
+    print(f"✅  Triggered Metabase sync for database id={db_id} ({etf_db['name']})")
+
+
+# ---------------------------------------------------------------------------
+# Build env dict for BashOperators that run dbt
+# ---------------------------------------------------------------------------
+def _dbt_env() -> dict[str, str]:
+    """Assemble env vars for dbt, sourced from the Airflow process environment."""
+    keys = ["DATABASE_URL", "DB_HOST", "DB_PORT", "DB_USER", "DB_PASSWORD", "DB_NAME", "DB_SSLMODE"]
+    env = {k: os.environ.get(k, "") for k in keys}
+    # Keep the system PATH so dbt binary is found
+    env["PATH"] = os.environ.get("PATH", "/home/airflow/.local/bin:/usr/local/bin:/usr/bin:/bin")
+    return env
+
+
+# ---------------------------------------------------------------------------
+# DAG definition
+# ---------------------------------------------------------------------------
+with DAG(
+    dag_id="etf_market_data_pipeline",
+    description="ELT: Yahoo Finance → PostgreSQL → dbt → Metabase",
+    default_args=default_args,
+    start_date=datetime(2024, 1, 1),
+    schedule="15 21 * * 1-5",
+    catchup=False,
+    max_active_runs=1,
+    tags=["etf", "yfinance", "dbt", "postgresql", "metabase"],
+    doc_md=__doc__,
+) as dag:
+
+    start = EmptyOperator(task_id="start")
+
+    # ── 1. Extract & Load ───────────────────────────────────────────────────
+    with TaskGroup("extract_load", tooltip="Ingest ETF data from Yahoo Finance into PostgreSQL") as tg_el:
+
+        init_db = PythonOperator(
+            task_id="init_database",
+            python_callable=_init_database,
+            doc_md="Create PostgreSQL tables from schema.sql (idempotent).",
+        )
+
+        load_sym = PythonOperator(
+            task_id="load_symbols",
+            python_callable=_load_symbols,
+            doc_md="Reload ETF symbols from analytics/database/reference/symbols.csv.",
+        )
+
+        fetch = PythonOperator(
+            task_id="fetch_market_data",
+            python_callable=_fetch_market_data,
+            doc_md=(
+                "Incrementally fetch OHLCV + FX rates from Yahoo Finance. "
+                "Only pulls dates newer than the latest record in PostgreSQL."
+            ),
+        )
+
+        init_db >> load_sym >> fetch
+
+    # ── 2. Transform ────────────────────────────────────────────────────────
+    with TaskGroup("transform", tooltip="dbt: staging → intermediate → marts") as tg_transform:
+
+        dbt_deps = BashOperator(
+            task_id="dbt_deps",
+            bash_command=f"cd {DBT_DIR} && dbt deps --profiles-dir .",
+            env=_dbt_env(),
+            doc_md="Install dbt packages declared in packages.yml.",
+        )
+
+        dbt_staging = BashOperator(
+            task_id="dbt_run_staging",
+            bash_command=f"cd {DBT_DIR} && dbt run --profiles-dir . --select staging",
+            env=_dbt_env(),
+            doc_md="Materialize staging views: clean + join raw tables.",
+        )
+
+        dbt_intermediate = BashOperator(
+            task_id="dbt_run_intermediate",
+            bash_command=f"cd {DBT_DIR} && dbt run --profiles-dir . --select intermediate",
+            env=_dbt_env(),
+            doc_md="Materialize intermediate views: EUR conversion with fallback logic.",
+        )
+
+        dbt_marts = BashOperator(
+            task_id="dbt_run_marts",
+            bash_command=f"cd {DBT_DIR} && dbt run --profiles-dir . --select marts",
+            env=_dbt_env(),
+            doc_md=(
+                "Materialize mart tables consumed by Metabase: "
+                "mart_price_history, mart_52week_metrics, mart_entry_thresholds."
+            ),
+        )
+
+        dbt_deps >> dbt_staging >> dbt_intermediate >> dbt_marts
+
+    # ── 3. Quality ──────────────────────────────────────────────────────────
+    with TaskGroup("quality", tooltip="dbt tests + source freshness (run in parallel)") as tg_quality:
+
+        dbt_test = BashOperator(
+            task_id="dbt_test",
+            bash_command=f"cd {DBT_DIR} && dbt test --profiles-dir .",
+            env=_dbt_env(),
+            doc_md="Run all dbt schema tests (not_null, unique, custom).",
+        )
+
+        dbt_freshness = BashOperator(
+            task_id="dbt_source_freshness",
+            bash_command=f"cd {DBT_DIR} && dbt source freshness --profiles-dir .",
+            env=_dbt_env(),
+            doc_md="Assert that raw source tables received data within the SLA window.",
+        )
+        # dbt_test and dbt_freshness run in parallel (no dependency between them)
+
+    # ── 4. Visualize (optional) ─────────────────────────────────────────────
+    with TaskGroup("visualize", tooltip="Refresh Metabase (skipped when METABASE_URL is not set)") as tg_viz:
+
+        check_metabase = ShortCircuitOperator(
+            task_id="check_metabase_configured",
+            python_callable=_should_sync_metabase,
+            doc_md="Skip the sync task when METABASE_URL Airflow Variable is not configured.",
+        )
+
+        sync_mb = PythonOperator(
+            task_id="sync_metabase",
+            python_callable=_sync_metabase,
+            doc_md=(
+                "Trigger Metabase schema resync so new dbt mart tables appear "
+                "in dashboards immediately. Requires METABASE_URL and "
+                "METABASE_API_KEY Airflow Variables."
+            ),
+        )
+
+        check_metabase >> sync_mb
+
+    # ── End (runs regardless of quality outcome to always mark pipeline done)
+    end = EmptyOperator(
+        task_id="end",
+        trigger_rule=TriggerRule.ALL_DONE,
+    )
+
+    # ── Wire task groups ────────────────────────────────────────────────────
+    start >> tg_el >> tg_transform >> tg_quality >> tg_viz >> end

--- a/airflow/docker-compose.yaml
+++ b/airflow/docker-compose.yaml
@@ -3,7 +3,6 @@ x-airflow-common:
   build:
     context: .
     dockerfile: Dockerfile
-  image: "${AIRFLOW_IMAGE_NAME:-apache/airflow:2.9.1}"
   env_file:
     - .env
   environment:
@@ -14,11 +13,25 @@ x-airflow-common:
     AIRFLOW__SCHEDULER__CATCHUP_BY_DEFAULT: "false"
     AIRFLOW__DATABASE__SQL_ALCHEMY_CONN: postgresql+psycopg2://airflow:airflow@postgres/airflow
     AIRFLOW__CORE__FERNET_KEY: ""
+    # Project path available inside all Airflow containers
     PYTHONPATH: /opt/airflow/project
+    # dbt profiles directory (profiles.yml lives in dbt/)
+    DBT_PROFILES_DIR: /opt/airflow/project/dbt
+    # PostgreSQL connection — set these in airflow/.env
+    # For local dev the defaults below match docker-compose.yml in the project root.
+    # For production point to your Supabase Session Pooler URL.
+    DATABASE_URL: ${DATABASE_URL:-postgresql://etf_user:etf_pass@host.docker.internal:5432/etf_db}
+    DB_HOST: ${DB_HOST:-host.docker.internal}
+    DB_PORT: ${DB_PORT:-5432}
+    DB_USER: ${DB_USER:-etf_user}
+    DB_PASSWORD: ${DB_PASSWORD:-etf_pass}
+    DB_NAME: ${DB_NAME:-etf_db}
+    DB_SSLMODE: ${DB_SSLMODE:-prefer}
   volumes:
     - ./dags:/opt/airflow/dags
     - ./logs:/opt/airflow/logs
     - ./plugins:/opt/airflow/plugins
+    # Entire repo available so DAGs can import analytics/ and run dbt/
     - ../:/opt/airflow/project
   user: "${AIRFLOW_UID:-50000}:${AIRFLOW_GID:-0}"
   depends_on:
@@ -29,7 +42,7 @@ x-airflow-common:
 
 services:
   postgres:
-    image: postgres:15
+    image: postgres:16
     environment:
       POSTGRES_USER: airflow
       POSTGRES_PASSWORD: airflow
@@ -49,7 +62,8 @@ services:
     command: >
       bash -c "
       airflow db migrate &&
-      airflow users create --role Admin --username admin --password admin --firstname Air --lastname Flow --email admin@example.com ||
+      airflow users create --role Admin --username admin --password admin
+        --firstname Air --lastname Flow --email admin@example.com ||
       true"
     restart: "no"
 
@@ -80,4 +94,3 @@ networks:
 
 volumes:
   postgres-db-volume:
-

--- a/airflow/env.example
+++ b/airflow/env.example
@@ -1,7 +1,22 @@
-# Airflow environment variables
-# Copy this file to .env (without extension) and adjust values.
-
+# Airflow process identity (keep these values)
 AIRFLOW_UID=50000
 AIRFLOW_GID=0
-AIRFLOW_IMAGE_NAME=apache/airflow:2.9.1
 
+# Custom image name built from airflow/Dockerfile
+AIRFLOW_IMAGE_NAME=etf-airflow:latest
+
+# ── PostgreSQL connection ───────────────────────────────────────────────────
+# Local dev: defaults point to the PostgreSQL container in docker-compose.yml
+# (project root). Run that stack first: cd .. && docker compose up -d postgres
+#
+# Production: use your Supabase Session Pooler URL (IPv4, required for GitHub
+# Actions and remote servers). Copy it from:
+# Supabase → Project Settings → Database → Connection pooling → Session mode.
+DATABASE_URL=postgresql://etf_user:etf_pass@host.docker.internal:5432/etf_db
+DB_HOST=host.docker.internal
+DB_PORT=5432
+DB_USER=etf_user
+DB_PASSWORD=etf_pass
+DB_NAME=etf_db
+# Use 'prefer' for local Docker; 'require' for Supabase / any hosted DB
+DB_SSLMODE=prefer

--- a/airflow/requirements.txt
+++ b/airflow/requirements.txt
@@ -1,6 +1,14 @@
 pandas>=1.5.0
 yfinance>=0.2.36
-SQLAlchemy>=1.4.0,<2.0.0
 python-dotenv>=1.0.0
 schedule>=1.2.0
 
+# PostgreSQL driver (same as project root requirements.txt)
+psycopg2-binary>=2.9.9
+
+# dbt — used by BashOperators in the ETF pipeline DAG
+dbt-core>=1.8.0
+dbt-postgres>=1.8.0
+
+# HTTP client — used by the Metabase sync task
+requests>=2.31.0

--- a/dbt/dbt_project.yml
+++ b/dbt/dbt_project.yml
@@ -20,7 +20,15 @@ models:
   etf_analytics:
     staging:
       +materialized: view
+      +tags: ["staging"]
     intermediate:
       +materialized: view
+      +tags: ["intermediate"]
     marts:
       +materialized: table
+      +tags: ["marts"]
+
+# Grant SELECT on mart tables to the read-only Metabase DB user (if one exists)
+# Uncomment when a read-only role is configured:
+# on-run-end:
+#   - "{% if target.name == 'prod' %}GRANT SELECT ON ALL TABLES IN SCHEMA public TO metabase_reader{% endif %}"

--- a/dbt/models/marts/schema.yml
+++ b/dbt/models/marts/schema.yml
@@ -3,40 +3,146 @@ version: 2
 models:
   - name: mart_price_history
     description: >
-      One row per ETF per trading day. Contains native-currency and EUR prices,
-      daily change metrics, and a 7-day rolling average. Primary table for
-      Metabase price history charts.
+      One row per ETF per trading day. The primary table consumed by Metabase
+      for price history charts and KPI cards.
+
+      Contains both native-currency and EUR prices, daily change metrics, and
+      a 7-day rolling average EUR close. Materialized as a table so Metabase
+      queries are fast without hitting the staging views each time.
     columns:
       - name: ticker
+        description: Yahoo Finance ticker (e.g. VOO, VUAA.L).
         tests: [not_null]
+      - name: etf_name
+        description: Full ETF name (e.g. Vanguard S&P 500 ETF).
+      - name: isin
+        description: International Securities Identification Number.
+      - name: exchange
+        description: Primary listing exchange.
+      - name: native_currency
+        description: Currency in which the ETF originally trades (USD or GBP).
       - name: date
+        description: Trading date (market calendar).
         tests: [not_null]
+      - name: open
+        description: Opening price in native currency.
+      - name: high
+        description: Intra-day high in native currency.
+      - name: low
+        description: Intra-day low in native currency.
       - name: close
+        description: Closing price in native currency.
         tests: [not_null]
+      - name: volume
+        description: Number of shares traded on this day.
+      - name: open_eur
+        description: Opening price converted to EUR.
+      - name: high_eur
+        description: Intra-day high converted to EUR.
+      - name: low_eur
+        description: Intra-day low converted to EUR.
       - name: close_eur
+        description: Closing price converted to EUR.
         tests: [not_null]
+      - name: daily_change
+        description: Absolute change in close price (native currency) vs open.
+      - name: daily_change_pct
+        description: Percentage change in close vs open (native currency).
+      - name: daily_change_eur
+        description: Absolute change in close_eur vs open_eur.
+      - name: daily_change_eur_pct
+        description: Percentage change in close_eur vs open_eur.
+      - name: close_eur_7d_avg
+        description: 7-day rolling average of close_eur. Useful for smoothing charts.
 
   - name: mart_52week_metrics
     description: >
-      Latest 52-week high/low per ETF, joined with the most recent price.
-      One row per ETF. Used for KPI cards and summary metrics table.
+      Latest 52-week high and low per ETF, joined with the most recent price.
+      One row per ETF. Used for KPI cards and the summary metrics table in Metabase.
     columns:
       - name: ticker
+        description: Yahoo Finance ticker.
         tests: [unique, not_null]
+      - name: etf_name
+        description: Full ETF name.
+      - name: isin
+        description: International Securities Identification Number.
+      - name: exchange
+        description: Primary listing exchange.
+      - name: native_currency
+        description: Native trading currency.
       - name: high_52week
+        description: Highest closing price over the preceding 52 weeks (native currency).
         tests: [not_null]
       - name: low_52week
+        description: Lowest closing price over the preceding 52 weeks (native currency).
         tests: [not_null]
+      - name: high_date
+        description: Date on which the 52-week high was recorded.
+      - name: low_date
+        description: Date on which the 52-week low was recorded.
+      - name: calculation_date
+        description: Date the metrics were last computed by the Python ETL.
+      - name: range_52week
+        description: Difference between the 52-week high and low (native currency).
+      - name: range_52week_pct
+        description: Range as a percentage of the 52-week low.
+      - name: latest_price_date
+        description: Date of the most recent close price available.
+      - name: latest_close
+        description: Most recent close price in native currency.
+      - name: latest_close_eur
+        description: Most recent close price in EUR.
+      - name: daily_change_eur_pct
+        description: Daily change percentage for the most recent trading day (EUR).
+      - name: distance_from_high
+        description: How far the current price is below the 52-week high (native currency).
+      - name: pct_below_52w_high
+        description: Current price as a percentage below the 52-week high.
+      - name: distance_from_low
+        description: How far the current price is above the 52-week low (native currency).
+      - name: pct_above_52w_low
+        description: Current price as a percentage above the 52-week low.
 
   - name: mart_entry_thresholds
     description: >
-      Entry point thresholds (5–30% below 52-week high) in long format.
-      One row per ETF per threshold level (6 rows per ETF = 30 total).
-      Used for the threshold bar chart and buying signal indicators.
+      Entry-point price levels at 5, 10, 15, 20, 25, and 30 percent below the
+      52-week high, in long (unpivoted) format. One row per ETF per threshold level
+      (6 levels × 5 ETFs = 30 rows total).
+
+      Used for the threshold bar chart and buying-signal indicators in Metabase.
+      The is_at_or_below_threshold flag makes it easy to build a conditional
+      color rule in Metabase: green when the price has reached a level.
     columns:
       - name: ticker
+        description: Yahoo Finance ticker.
         tests: [not_null]
+      - name: etf_name
+        description: Full ETF name.
+      - name: exchange
+        description: Primary listing exchange.
+      - name: native_currency
+        description: Native trading currency.
+      - name: calculation_date
+        description: Date the thresholds were last calculated.
+      - name: high_52week_price
+        description: The 52-week high price used as the reference for threshold calculations.
       - name: pct_below
+        description: Threshold level as an integer percentage (5, 10, 15, 20, 25, or 30).
         tests: [not_null]
       - name: threshold_price
+        description: Absolute price corresponding to this pct_below level.
         tests: [not_null]
+      - name: is_at_or_below_threshold
+        description: >
+          True when the current price is at or below the threshold price.
+          Use this column for conditional coloring in Metabase charts.
+      - name: gap_to_threshold
+        description: >
+          Current price minus threshold price (negative means price is below threshold).
+      - name: gap_to_threshold_pct
+        description: gap_to_threshold expressed as a percentage of the threshold price.
+      - name: latest_close
+        description: Most recent close price (native currency).
+      - name: latest_close_eur
+        description: Most recent close price in EUR.

--- a/dbt/models/staging/schema.yml
+++ b/dbt/models/staging/schema.yml
@@ -1,0 +1,57 @@
+version: 2
+
+models:
+  - name: stg_etf_data
+    description: >
+      Cleaned daily OHLCV prices joined with ETF metadata.
+      Filters to active symbols only. One row per active ETF per trading day.
+    columns:
+      - name: id
+        description: Raw primary key from etf_data.
+        tests: [unique, not_null]
+      - name: symbol_id
+        tests: [not_null]
+      - name: ticker
+        description: Yahoo Finance ticker (e.g. VOO, VUAA.L).
+        tests: [not_null]
+      - name: etf_name
+        description: Full ETF name from the symbols reference table.
+      - name: isin
+        description: International Securities Identification Number.
+      - name: exchange
+        description: Listing exchange (NYSE, NASDAQ, LSE).
+      - name: native_currency
+        description: Currency in which the ETF is priced (USD, GBP).
+      - name: date
+        description: Trading date.
+        tests: [not_null]
+      - name: open
+        description: Opening price in native currency.
+      - name: high
+        description: Intra-day high in native currency.
+      - name: low
+        description: Intra-day low in native currency.
+      - name: close
+        description: Closing price in native currency.
+        tests: [not_null]
+      - name: volume
+        description: Number of shares traded.
+      - name: close_eur
+        description: Closing price converted to EUR (may be null before int_etf_eur runs).
+
+  - name: stg_currency_rates
+    description: >
+      Validated historical FX exchange rates.
+      Filters out zero and negative rates that indicate missing Yahoo Finance data.
+    columns:
+      - name: id
+        tests: [unique, not_null]
+      - name: from_currency
+        tests: [not_null]
+      - name: to_currency
+        tests: [not_null]
+      - name: rate_date
+        tests: [not_null]
+      - name: exchange_rate
+        description: Spot exchange rate. Always positive (zero rates filtered out).
+        tests: [not_null]

--- a/dbt/models/staging/sources.yml
+++ b/dbt/models/staging/sources.yml
@@ -2,47 +2,96 @@ version: 2
 
 sources:
   - name: raw
-    description: Raw tables written by the Python ETL pipeline
+    description: >
+      Raw tables written by the Python ETL pipeline (analytics/etl/).
+      These are the system-of-record tables that dbt reads but never writes to.
     schema: public
+
+    # Source freshness: warn if etf_data hasn't received new rows in 12 h,
+    # error if not updated in 24 h. Checked by `dbt source freshness`.
+    freshness:
+      warn_after: {count: 12, period: hour}
+      error_after: {count: 24, period: hour}
+
     tables:
       - name: etf_data
-        description: Raw OHLCV price data per ETF per day
+        description: >
+          Raw OHLCV price data per ETF per trading day, written by the
+          EnhancedMarketDataFetcher. Also stores EUR-converted price columns
+          populated by the CurrencyConverter ETL step.
+        loaded_at_field: created_at
+        freshness:
+          warn_after: {count: 12, period: hour}
+          error_after: {count: 24, period: hour}
         columns:
           - name: id
+            description: Surrogate primary key.
             tests: [unique, not_null]
           - name: symbol_id
+            description: Foreign key to the symbols table.
             tests: [not_null]
           - name: date
+            description: Trading date (market calendar date, not a timestamp).
             tests: [not_null]
           - name: close
+            description: Closing price in the ETF's native currency.
             tests: [not_null]
+          - name: close_eur
+            description: Closing price converted to EUR using historical FX rates.
 
       - name: symbols
-        description: ETF metadata (ticker, ISIN, currency)
+        description: >
+          Reference table of tracked ETFs. Loaded from
+          analytics/database/reference/symbols.csv.
         columns:
           - name: id
+            description: Surrogate primary key.
             tests: [unique, not_null]
           - name: ticker
+            description: Yahoo Finance ticker symbol (e.g. VOO, VUAA.L).
             tests: [unique, not_null]
+          - name: isin
+            description: International Securities Identification Number.
+            tests: [unique, not_null]
+          - name: currency
+            description: Native trading currency (USD, GBP, EUR).
 
       - name: currency_rates
-        description: Cached historical EUR exchange rates
+        description: >
+          Historical FX exchange rates cached from Yahoo Finance
+          (USDEUR=X, GBPEUR=X). Used by the intermediate layer to fill gaps
+          in EUR-converted prices.
         columns:
           - name: from_currency
+            description: Source currency code (e.g. USD, GBP).
+            tests: [not_null]
+          - name: to_currency
+            description: Target currency code (always EUR in this project).
             tests: [not_null]
           - name: rate_date
+            description: Date for which this exchange rate applies.
             tests: [not_null]
+          - name: exchange_rate
+            description: Spot rate on rate_date (from_currency → to_currency).
 
       - name: fifty_two_week_metrics
-        description: Calculated 52-week high/low metrics
+        description: >
+          52-week high and low prices calculated by the Python ETL at the end
+          of each incremental fetch. One row per symbol per calculation date.
         columns:
           - name: symbol_id
             tests: [not_null]
           - name: calculation_date
             tests: [not_null]
+          - name: high_52week
+            description: Highest closing price over the preceding 52 weeks.
+          - name: low_52week
+            description: Lowest closing price over the preceding 52 weeks.
 
       - name: decrease_thresholds
-        description: Entry point thresholds at 5–30% below 52-week high
+        description: >
+          Entry-point price levels at 5, 10, 15, 20, 25, and 30 percent below
+          the 52-week high. Computed by the Python ETL alongside 52-week metrics.
         columns:
           - name: symbol_id
             tests: [not_null]

--- a/dbt/packages.yml
+++ b/dbt/packages.yml
@@ -1,0 +1,3 @@
+packages:
+  - package: dbt-labs/dbt_utils
+    version: [">=1.0.0", "<2.0.0"]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What this PR delivers

A recruiter-ready Data Engineering pipeline. Every component is wired together end-to-end with clean code, proper documentation, and automated visualization.

---

## Airflow DAG — `airflow/dags/etf_pipeline.py`

The centrepiece of the portfolio. A single DAG with four TaskGroups:

```
start
 └── extract_load
      ├── init_database       PythonOperator — idempotent schema creation
      ├── load_symbols        PythonOperator — reload ETF reference CSV
      └── fetch_market_data   PythonOperator — incremental Yahoo Finance fetch
 └── transform
      ├── dbt_run_staging        BashOperator — stg_etf_data, stg_currency_rates
      ├── dbt_run_intermediate   BashOperator — int_etf_eur
      └── dbt_run_marts          BashOperator — price_history, 52w_metrics, thresholds
 └── quality                  (parallel)
      ├── dbt_test               BashOperator — schema + custom tests
      └── dbt_source_freshness   BashOperator — SLA check (warn >12h, error >24h)
 └── visualize
      ├── check_metabase_configured   ShortCircuitOperator — skips if METABASE_URL unset
      └── sync_metabase               PythonOperator — Metabase REST API schema resync
 └── end (TriggerRule.ALL_DONE)
```

Key patterns shown:
- `TaskGroup` for logical grouping
- `ShortCircuitOperator` for conditional execution
- `TriggerRule.ALL_DONE` on end task
- `retries=2`, `retry_delay=5min` on all tasks
- `max_active_runs=1` to prevent overlapping runs
- XCom-compatible return value from `fetch_market_data`
- Full module docstring explaining the pipeline

## Airflow infrastructure

- `requirements.txt` — adds `psycopg2-binary`, `dbt-core`, `dbt-postgres`, `requests`
- `docker-compose.yaml` — passes `DATABASE_URL`, all `DB_*` vars, and `DB_SSLMODE` to every Airflow service; documents `host.docker.internal` for local dev
- `env.example` — complete template with inline comments

## dbt improvements

- `packages.yml` — adds `dbt_utils` (eliminates the "no packages found" warning in CI)
- `sources.yml` — source freshness SLA on `etf_data` (warn >12h, error >24h); full column descriptions on all 5 raw tables
- `staging/schema.yml` — new file with stg_* model and column documentation
- `marts/schema.yml` — full column descriptions on all 3 mart tables (30+ columns documented)
- `dbt_project.yml` — `+tags` per layer; commented grant template for Metabase read-only role

## GitHub Actions

- `deploy-website.yml` — removed broken Python data-generation steps; now a clean static deploy of `website/` to GitHub Pages

## README

Portfolio-grade rewrite:
- ASCII architecture diagram showing all components
- Full pipeline walkthrough with task names
- dbt model tree with descriptions
- Local dev quickstart (Airflow + dbt + Metabase)
- Production setup table (Supabase + Oracle + GitHub Actions)
- Complete directory structure

---

## Local dev after merge

```bash
# Start the full local stack
cd airflow && cp env.example .env && docker compose up -d --build && cd ..
# Open Airflow at http://localhost:8080 (admin/admin)
# Trigger etf_market_data_pipeline
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-64fcc1db-6cef-4360-a6e6-889b90a77a1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-64fcc1db-6cef-4360-a6e6-889b90a77a1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

