### PR TITLE
feat: Oracle Cloud auto-setup for always-on free Metabase

### DIFF
--- a/analytics/docs/oracle-vm-setup.md
+++ b/analytics/docs/oracle-vm-setup.md
@@ -1,0 +1,139 @@
+# Get Metabase Live — Oracle Cloud Setup
+
+**Goal:** dashboard accessible from any browser, always on, zero cost, zero daily work.
+
+**Time needed:** ~20 minutes (one time only).
+
+---
+
+## Step 1 — Create your Oracle Cloud account (5 min)
+
+1. Go to [cloud.oracle.com](https://cloud.oracle.com)
+2. Click **Start for free**
+3. Fill in your details — **no credit card required** for Always Free resources
+4. Verify your email and complete signup
+
+---
+
+## Step 2 — Create the VM (5 min)
+
+1. Log in → click **Create a VM instance**
+2. Change the name to `etf-metabase` (optional)
+3. Under **Image and shape**, click **Change shape**
+   - Select **Ampere** tab
+   - Choose `VM.Standard.A1.Flex`
+   - Set **OCPUs: 2**, **Memory: 12 GB**
+   - Click **Select shape**
+4. Confirm the image is **Ubuntu 22.04**
+5. Under **Add SSH keys**, choose **Generate a key pair for me** and download both files (you may need them later)
+6. Scroll down to **Advanced options → Management**
+7. Under **User data**, paste the entire contents of [`scripts/oracle-cloud-init.yml`](../../scripts/oracle-cloud-init.yml)
+8. Click **Create**
+
+The VM will be ready in about 2 minutes.
+
+---
+
+## Step 3 — Open port 3000 in Oracle's firewall (5 min)
+
+Oracle has a separate network-level firewall you must open manually.
+
+1. On the instance detail page, click the **Subnet** link
+2. Click **Default Security List**
+3. Click **Add Ingress Rules**
+4. Fill in:
+   - Source CIDR: `0.0.0.0/0`
+   - IP Protocol: TCP
+   - Destination Port Range: `3000`
+5. Click **Add Ingress Rules**
+
+---
+
+## Step 4 — Wait for Metabase to start (~3 min)
+
+Find your VM's **Public IP address** on the instance detail page.
+
+Open in your browser:
+```
+http://<your-public-ip>:3000
+```
+
+If you see a loading screen, wait 2–3 minutes — Metabase (Java) takes a moment on first boot.
+
+---
+
+## Step 5 — Connect Metabase to Supabase (5 min)
+
+1. Complete the Metabase setup wizard (create your admin account)
+2. When asked about data, choose **I'll add my data later**
+3. Go to **Admin → Databases → Add a database**
+
+Fill in these fields:
+
+| Field | Value |
+|---|---|
+| Database type | PostgreSQL |
+| Display name | ETF Analytics |
+| Host | your Supabase host (from the Session Pooler URL: `aws-0-[region].pooler.supabase.com`) |
+| Port | `5432` |
+| Database name | `postgres` |
+| Username | `postgres.[your-project-ref]` |
+| Password | your Supabase DB password |
+| SSL mode | Required |
+
+> Your Supabase Session Pooler URL has this format:
+> `postgresql://postgres.[ref]:[password]@aws-0-[region].pooler.supabase.com:5432/postgres`
+> The username is everything between `//` and `:`, the host is after `@`.
+
+4. Click **Save** — Metabase will sync the schema (~1 minute)
+5. You should see the 3 mart tables: `mart_price_history`, `mart_52week_metrics`, `mart_entry_thresholds`
+
+---
+
+## Step 6 — Build the dashboard with Cursor AI (optional)
+
+Enable MCP in Metabase so Cursor can build the dashboard for you:
+
+1. Go to **Admin → AI → MCP** → toggle **MCP server ON**
+2. Enable **Cursor and VS Code**
+
+Add to Cursor settings (Settings → MCP Servers):
+
+```json
+{
+  "mcpServers": {
+    "metabase": {
+      "url": "http://<your-oracle-ip>:3000/api/metabase-mcp",
+      "transport": "streamable-http"
+    }
+  }
+}
+```
+
+Then in Cursor chat, use the prompt in [`analytics/docs/metabase_setup.md`](metabase_setup.md#6-build-the-dashboard-with-cursor-ai).
+
+---
+
+## Done
+
+Your dashboard is live at `http://<your-oracle-ip>:3000`.
+
+GitHub Actions refreshes the data every weekday night at 21:15 UTC.
+You open the URL, see today's data, close the browser. Nothing to run.
+
+---
+
+## Troubleshooting
+
+**Browser shows "connection refused"**
+- Wait another 2–3 minutes — Metabase starts slowly on first boot
+- Check Oracle security list has port 3000 open (Step 3)
+
+**Metabase loads but shows no tables**
+- Go to Admin → Databases → click your DB → Sync database schema
+- Check the connection credentials match your Supabase Session Pooler URL exactly
+
+**VM public IP changed after reboot**
+- Oracle Always Free VMs use ephemeral IPs by default
+- Assign a **Reserved Public IP** (free) to make the IP permanent:
+  Instance details → Primary VNIC → IP address → Reserve

--- a/scripts/oracle-cloud-init.yml
+++ b/scripts/oracle-cloud-init.yml
@@ -1,0 +1,67 @@
+#cloud-config
+#
+# Oracle Cloud VM — auto-setup script for Metabase
+# -------------------------------------------------
+# Paste this entire file into the "User data" field when creating
+# the VM on Oracle Cloud. It runs automatically on first boot.
+#
+# What it does:
+#   1. Installs Docker
+#   2. Writes the Metabase docker-compose file
+#   3. Starts Metabase on port 3000
+#   4. Opens port 3000 in the OS firewall (iptables)
+#
+# After the VM boots (~3 min) open: http://<your-oracle-ip>:3000
+
+package_update: true
+package_upgrade: false
+
+packages:
+  - docker.io
+  - docker-compose-plugin
+  - iptables-persistent
+
+runcmd:
+  # Allow ubuntu user to run Docker without sudo
+  - usermod -aG docker ubuntu
+
+  # Create app directory
+  - mkdir -p /opt/metabase
+
+  # Write the Metabase compose file
+  - |
+    cat > /opt/metabase/docker-compose.yml << 'COMPOSE'
+    services:
+      metabase:
+        image: metabase/metabase:latest
+        container_name: etf_metabase
+        restart: always
+        ports:
+          - "3000:3000"
+        volumes:
+          - metabase_data:/metabase-data
+        environment:
+          MB_DB_TYPE: h2
+          MB_DB_FILE: /metabase-data/metabase.db
+          MB_LOAD_SAMPLE_CONTENT: "false"
+          MB_INSTALL_ANALYTICS_DATABASE: "false"
+    volumes:
+      metabase_data:
+    COMPOSE
+
+  # Start Metabase
+  - cd /opt/metabase && docker compose up -d
+
+  # Open port 3000 in OS-level firewall
+  - iptables -I INPUT -p tcp --dport 3000 -j ACCEPT
+  - iptables -I INPUT -p tcp --dport 22 -j ACCEPT
+
+  # Persist iptables rules across reboots (non-interactive)
+  - echo "iptables-persistent iptables-persistent/autosave_v4 boolean true" | debconf-set-selections
+  - echo "iptables-persistent iptables-persistent/autosave_v6 boolean true" | debconf-set-selections
+  - netfilter-persistent save
+
+final_message: |
+  ✅ Metabase setup complete.
+  Open http://<this-vm-public-ip>:3000 in your browser.
+  First startup takes ~3 minutes (JVM warmup).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What this adds

Everything needed to get Metabase live at a permanent URL, free, with no local Docker.

### `scripts/oracle-cloud-init.yml`

A `#cloud-config` script you paste into the **User Data** field when creating the Oracle VM. On first boot it automatically:
1. Installs Docker
2. Writes the Metabase compose file
3. Starts Metabase on port 3000
4. Opens port 3000 in the OS-level iptables firewall (persisted across reboots)

No SSH required.

### `analytics/docs/oracle-vm-setup.md`

Dead-simple 6-step guide (~20 min one-time):
1. Create Oracle Cloud free account
2. Create ARM VM with the cloud-init script pasted in
3. Open port 3000 in Oracle's security list (one click)
4. Connect Metabase to Supabase (credentials from existing `DATABASE_URL` secret)
5. Build dashboard via Cursor MCP
6. Done — `http://<oracle-ip>:3000` is live forever

Includes troubleshooting for the 3 most common issues (connection refused, no tables, IP changed).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-64fcc1db-6cef-4360-a6e6-889b90a77a1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-64fcc1db-6cef-4360-a6e6-889b90a77a1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

