### PR TITLE
feat: Grafana Cloud dashboard — always-on, no server, no card needed

### DIFF
--- a/.github/workflows/production_automation.yml
+++ b/.github/workflows/production_automation.yml
@@ -81,3 +81,16 @@ jobs:
         dbt run --profiles-dir .
         dbt test --profiles-dir .
         cd ..
+
+    - name: Provision Grafana dashboard (runs only when GRAFANA secrets are set)
+      env:
+        GRAFANA_URL: ${{ secrets.GRAFANA_URL }}
+        GRAFANA_API_KEY: ${{ secrets.GRAFANA_API_KEY }}
+      run: |
+        if [ -n "$GRAFANA_URL" ] && [ -n "$GRAFANA_API_KEY" ]; then
+          echo "Provisioning Grafana dashboard..."
+          pip install requests --quiet
+          python scripts/provision_grafana.py
+        else
+          echo "GRAFANA_URL / GRAFANA_API_KEY not set — skipping Grafana step"
+        fi

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Demonstrates a complete, automated ELT pipeline from raw market data to live das
 | **Extract & Load** | Python + yfinance | Incremental fetch from Yahoo Finance → PostgreSQL |
 | **Transform** | dbt Core 1.8 | Staging → Intermediate → Mart models |
 | **Warehouse** | PostgreSQL 16 | Single source of truth (Supabase in production) |
-| **Visualization** | Metabase OSS | Live dashboards built via MCP + AI |
+| **Visualization** | Grafana Cloud (free) | Always-on dashboards, no server needed |
 | **CI / CD** | GitHub Actions | Tests on every PR; daily pipeline run in production |
 | **Infrastructure** | Docker Compose | Local dev (Airflow + PostgreSQL + Metabase) |
 
@@ -73,8 +73,8 @@ Demonstrates a complete, automated ELT pipeline from raw market data to live das
            │    ├── dbt_test               schema tests: not_null, unique
            │    └── dbt_source_freshness   SLA: warn >12 h, error >24 h
            │
-           └── visualize              (skipped when METABASE_URL not set)
-                └── sync_metabase      Metabase schema resync via REST API
+           └── visualize              (skipped when GRAFANA_URL not set)
+                └── provision_grafana  Grafana dashboard provisioning via REST API
 ```
 
 ---
@@ -162,16 +162,16 @@ dbt docs serve --profiles-dir .           # serve at http://localhost:8080
 
 | Service | Provider | Cost |
 |---|---|---|
-| PostgreSQL | [Supabase](https://supabase.com) free tier (500 MB) | Free |
+| PostgreSQL | [Supabase](https://supabase.com) free tier | Free |
 | Daily pipeline | GitHub Actions (schedule trigger) | Free |
-| Metabase dashboard | [Oracle Cloud Always Free](https://www.oracle.com/cloud/free/) ARM VM | Free |
+| Dashboard | [Grafana Cloud](https://grafana.com) free tier | Free |
 
-**After one-time setup:** open `http://<oracle-ip>:3000` from any browser.
-Data refreshes every weekday night automatically via GitHub Actions.
+**After one-time setup:** open your permanent Grafana URL from any device.
+Data refreshes every weekday night automatically. Nothing to run or start.
 
-Required GitHub secret: `DATABASE_URL` (Supabase Session Pooler URL — IPv4).
+Required GitHub secrets: `DATABASE_URL`, `GRAFANA_URL`, `GRAFANA_API_KEY`
 
-→ Full setup guide: `analytics/docs/metabase_setup.md`
+→ Full setup guide: `analytics/docs/grafana_setup.md`
 
 ---
 
@@ -222,7 +222,7 @@ stock-market/
 
 | File | Topic |
 |---|---|
-| `analytics/docs/metabase_setup.md` | Metabase local + production (Oracle + Supabase) |
+| `analytics/docs/grafana_setup.md` | Grafana Cloud setup (15 min, no card needed) |
 | `analytics/docs/stock-market-v1.md` | v1 architecture decisions |
 | `analytics/docs/airflow_setup.md` | Airflow local setup guide |
 

--- a/analytics/docs/grafana_setup.md
+++ b/analytics/docs/grafana_setup.md
@@ -1,0 +1,99 @@
+# Grafana Cloud Setup — ETF Analytics Dashboard
+
+**Goal:** live dashboard at a permanent URL, always on, cost-free, no server to manage.
+
+**Time needed:** ~15 minutes (one time only).
+
+---
+
+## Step 1 — Get your Grafana API token (2 min)
+
+1. Log in at [grafana.com](https://grafana.com)
+2. Go to **Administration → Service accounts**
+3. Click **Add service account** → name it `etf-pipeline` → role **Admin**
+4. Click **Add service account token** → copy the token (starts with `glsa_...`)
+
+Keep this token safe — you need it in Steps 2 and 3.
+
+---
+
+## Step 2 — Add GitHub secrets (2 min)
+
+Go to your GitHub repo → **Settings → Secrets and variables → Actions** → add:
+
+| Secret name | Value |
+|---|---|
+| `GRAFANA_URL` | Your Grafana instance URL, e.g. `https://yourname.grafana.net` |
+| `GRAFANA_API_KEY` | The token you copied in Step 1 |
+
+Your `DATABASE_URL` secret is already set from the Supabase setup.
+
+---
+
+## Step 3 — Run the provisioning script (1 min)
+
+The script creates the PostgreSQL data source and builds the full dashboard automatically.
+
+**Option A — via GitHub Actions (recommended, no local install needed):**
+
+Go to your repo → **Actions → Production Market Data Automation** → **Run workflow**.
+
+The workflow already includes an optional Grafana step — it runs automatically when
+`GRAFANA_URL` and `GRAFANA_API_KEY` are set.
+
+**Option B — locally:**
+
+```bash
+pip install requests
+export GRAFANA_URL=https://yourname.grafana.net
+export GRAFANA_API_KEY=glsa_...
+export DATABASE_URL=postgresql://postgres.xxx:pass@aws-0-xxx.pooler.supabase.com:5432/postgres
+
+python scripts/provision_grafana.py
+```
+
+---
+
+## Step 4 — Open your dashboard
+
+The script prints the dashboard URL at the end. It looks like:
+
+```
+https://yourname.grafana.net/d/etf-analytics-v1/etf-analytics-dashboard
+```
+
+Bookmark it. That URL is permanent and always shows the latest data.
+
+---
+
+## What the dashboard includes
+
+| Panel | Type | Data source |
+|---|---|---|
+| ETF KPI cards (price + daily Δ%) | Stat | `mart_52week_metrics` |
+| Price history (all ETFs, EUR) | Time series | `mart_price_history` |
+| 52-Week metrics summary | Table | `mart_52week_metrics` |
+| Entry point thresholds (5–30%) | Table | `mart_entry_thresholds` |
+
+---
+
+## Daily routine after setup
+
+GitHub Actions updates Supabase every weekday at 21:15 UTC (Berlin time).
+Open your Grafana URL any time — data is always from the previous evening.
+
+**Nothing to run. Nothing to start. Just open the URL.**
+
+---
+
+## Troubleshooting
+
+**"Data source not found" error in the script**
+→ The script creates it automatically using `DATABASE_URL`. Make sure the secret is the Supabase Session Pooler URL (starts with `aws-0-...`).
+
+**Dashboard shows "No data"**
+→ Go to Grafana → Connections → your data source → Test connection.
+→ Make sure the GitHub Actions pipeline has run at least once successfully.
+
+**Dashboard URL changed**
+→ It won't — the UID `etf-analytics-v1` is fixed in the script. The URL is always the same.

--- a/scripts/provision_grafana.py
+++ b/scripts/provision_grafana.py
@@ -1,0 +1,401 @@
+#!/usr/bin/env python3
+"""Provision Grafana Cloud with the ETF Analytics dashboard.
+
+Run this script once after creating your Grafana account, or re-run it
+whenever you want to update the dashboard definition. It is idempotent —
+running it multiple times is safe.
+
+Required environment variables
+-------------------------------
+GRAFANA_URL     Base URL of your Grafana instance
+                e.g. https://yourname.grafana.net
+GRAFANA_API_KEY Service account token with Admin role
+                Grafana → Administration → Service accounts → Add token
+DATABASE_URL    Supabase Session Pooler connection string (same secret used
+                by GitHub Actions for the daily pipeline)
+
+Usage
+-----
+    export GRAFANA_URL=https://yourname.grafana.net
+    export GRAFANA_API_KEY=glsa_...
+    export DATABASE_URL=postgresql://postgres.xxx:pass@aws-0-xxx.pooler.supabase.com:5432/postgres
+    python scripts/provision_grafana.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from urllib.parse import urlparse
+
+import requests
+
+GRAFANA_URL = os.environ.get("GRAFANA_URL", "").rstrip("/")
+GRAFANA_API_KEY = os.environ.get("GRAFANA_API_KEY", "")
+DATABASE_URL = os.environ.get("DATABASE_URL", "")
+
+DATASOURCE_NAME = "ETF Analytics"
+DASHBOARD_UID = "etf-analytics-v1"
+DASHBOARD_TITLE = "ETF Analytics Dashboard"
+GRAFANA_JSON_PATH = os.path.join(os.path.dirname(__file__), "..", "grafana", "etf_dashboard.json")
+
+
+# ---------------------------------------------------------------------------
+# HTTP helpers
+# ---------------------------------------------------------------------------
+
+def _headers() -> dict:
+    return {
+        "Authorization": f"Bearer {GRAFANA_API_KEY}",
+        "Content-Type": "application/json",
+    }
+
+
+def _get(path: str) -> requests.Response:
+    r = requests.get(f"{GRAFANA_URL}{path}", headers=_headers(), timeout=30)
+    r.raise_for_status()
+    return r
+
+
+def _post(path: str, payload: dict) -> requests.Response:
+    r = requests.post(f"{GRAFANA_URL}{path}", headers=_headers(), json=payload, timeout=30)
+    r.raise_for_status()
+    return r
+
+
+def _put(path: str, payload: dict) -> requests.Response:
+    r = requests.put(f"{GRAFANA_URL}{path}", headers=_headers(), json=payload, timeout=30)
+    r.raise_for_status()
+    return r
+
+
+# ---------------------------------------------------------------------------
+# Data source
+# ---------------------------------------------------------------------------
+
+def get_or_create_datasource() -> str:
+    """Return the UID of the ETF Analytics PostgreSQL data source, creating it if needed."""
+    existing = {ds["name"]: ds for ds in _get("/api/datasources").json()}
+
+    if DATASOURCE_NAME in existing:
+        uid = existing[DATASOURCE_NAME]["uid"]
+        print(f"✅  Data source '{DATASOURCE_NAME}' already exists  (uid: {uid})")
+        return uid
+
+    if not DATABASE_URL:
+        print(
+            "⚠️   DATABASE_URL is not set. Create the data source manually:\n"
+            "     Grafana → Connections → Add data source → PostgreSQL\n"
+            f"    Name it exactly: {DATASOURCE_NAME!r}"
+        )
+        sys.exit(1)
+
+    parsed = urlparse(DATABASE_URL)
+    payload = {
+        "name": DATASOURCE_NAME,
+        "type": "grafana-postgresql-datasource",
+        "access": "proxy",
+        "url": f"{parsed.hostname}:{parsed.port or 5432}",
+        "user": parsed.username,
+        "database": parsed.path.lstrip("/"),
+        "secureJsonData": {"password": parsed.password},
+        "jsonData": {
+            "sslmode": "require",
+            "postgresVersion": 1600,
+            "timescaledb": False,
+        },
+        "isDefault": True,
+    }
+    uid = _post("/api/datasources", payload).json()["datasource"]["uid"]
+    print(f"✅  Created data source '{DATASOURCE_NAME}'  (uid: {uid})")
+    return uid
+
+
+# ---------------------------------------------------------------------------
+# Dashboard builder
+# ---------------------------------------------------------------------------
+
+def _ds_ref(uid: str) -> dict:
+    return {"type": "grafana-postgresql-datasource", "uid": uid}
+
+
+def _sql_target(sql: str, ref_id: str = "A", fmt: str = "table") -> dict:
+    return {"rawSql": sql.strip(), "format": fmt, "refId": ref_id}
+
+
+def build_dashboard(ds_uid: str) -> dict:
+    """Return the full Grafana dashboard definition as a Python dict."""
+    ds = _ds_ref(ds_uid)
+    panels: list[dict] = []
+    pid = 1
+    y = 0
+
+    # ── Row 1: KPI stat cards — one per ETF ──────────────────────────────────
+    etfs = ["VOO", "VTI", "QQQ", "VUAA.L", "CNDX.L"]
+    widths = [5, 5, 5, 5, 4]   # sums to 24
+    x = 0
+    for i, (ticker, w) in enumerate(zip(etfs, widths)):
+        panels.append({
+            "id": pid, "type": "stat",
+            "title": ticker,
+            "gridPos": {"x": x, "y": y, "w": w, "h": 5},
+            "datasource": ds,
+            "targets": [_sql_target(
+                f"SELECT latest_close_eur AS \"Price (EUR)\", "
+                f"daily_change_eur_pct AS \"Daily Δ%\" "
+                f"FROM mart_52week_metrics WHERE ticker = '{ticker}'",
+                fmt="table"
+            )],
+            "options": {
+                "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": False},
+                "orientation": "vertical",
+                "colorMode": "background",
+                "graphMode": "none",
+                "textMode": "auto",
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {"color": "red", "value": None},
+                            {"color": "green", "value": 0},
+                        ],
+                    },
+                },
+                "overrides": [
+                    {
+                        "matcher": {"id": "byName", "options": "Price (EUR)"},
+                        "properties": [{"id": "unit", "value": "currencyEUR"}],
+                    },
+                    {
+                        "matcher": {"id": "byName", "options": "Daily Δ%"},
+                        "properties": [{"id": "unit", "value": "percent"}],
+                    },
+                ],
+            },
+        })
+        pid += 1
+        x += w
+    y += 5
+
+    # ── Row 2: Price History time series ─────────────────────────────────────
+    price_sql = """
+SELECT
+  date::timestamp AS time,
+  MAX(CASE WHEN ticker = 'VOO'    THEN close_eur END) AS "VOO",
+  MAX(CASE WHEN ticker = 'VTI'    THEN close_eur END) AS "VTI",
+  MAX(CASE WHEN ticker = 'QQQ'    THEN close_eur END) AS "QQQ",
+  MAX(CASE WHEN ticker = 'VUAA.L' THEN close_eur END) AS "VUAA.L",
+  MAX(CASE WHEN ticker = 'CNDX.L' THEN close_eur END) AS "CNDX.L"
+FROM mart_price_history
+WHERE date >= $__timeFrom()::date AND date <= $__timeTo()::date
+GROUP BY date
+ORDER BY date
+"""
+    panels.append({
+        "id": pid, "type": "timeseries",
+        "title": "Price History — EUR (use time picker to zoom)",
+        "gridPos": {"x": 0, "y": y, "w": 24, "h": 12},
+        "datasource": ds,
+        "targets": [_sql_target(price_sql, fmt="time_series")],
+        "fieldConfig": {
+            "defaults": {
+                "unit": "currencyEUR",
+                "custom": {"lineWidth": 2, "fillOpacity": 5, "spanNulls": True},
+            },
+            "overrides": [],
+        },
+        "options": {
+            "tooltip": {"mode": "multi", "sort": "none"},
+            "legend": {
+                "displayMode": "table",
+                "placement": "bottom",
+                "calcs": ["lastNotNull", "min", "max"],
+            },
+        },
+    })
+    pid += 1
+    y += 12
+
+    # ── Row 3: 52-Week Metrics table ─────────────────────────────────────────
+    metrics_sql = """
+SELECT
+  ticker                 AS "Ticker",
+  etf_name               AS "ETF Name",
+  latest_close_eur       AS "Price (EUR)",
+  daily_change_eur_pct   AS "Daily Δ%",
+  high_52week            AS "52w High",
+  low_52week             AS "52w Low",
+  pct_below_52w_high     AS "% Below High",
+  pct_above_52w_low      AS "% Above Low",
+  latest_price_date      AS "Last Updated"
+FROM mart_52week_metrics
+ORDER BY ticker
+"""
+    panels.append({
+        "id": pid, "type": "table",
+        "title": "52-Week Metrics",
+        "gridPos": {"x": 0, "y": y, "w": 24, "h": 8},
+        "datasource": ds,
+        "targets": [_sql_target(metrics_sql)],
+        "fieldConfig": {
+            "defaults": {"custom": {"align": "auto", "inspect": False}},
+            "overrides": [
+                {
+                    "matcher": {"id": "byName", "options": "Price (EUR)"},
+                    "properties": [{"id": "unit", "value": "currencyEUR"}],
+                },
+                {
+                    "matcher": {"id": "byName", "options": "Daily Δ%"},
+                    "properties": [
+                        {"id": "unit", "value": "percent"},
+                        {"id": "custom.displayMode", "value": "color-text"},
+                        {
+                            "id": "thresholds",
+                            "value": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {"color": "red", "value": None},
+                                    {"color": "green", "value": 0},
+                                ],
+                            },
+                        },
+                    ],
+                },
+                {
+                    "matcher": {"id": "byName", "options": "% Below High"},
+                    "properties": [
+                        {"id": "unit", "value": "percent"},
+                        {"id": "custom.displayMode", "value": "color-background"},
+                        {
+                            "id": "thresholds",
+                            "value": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {"color": "green", "value": None},
+                                    {"color": "yellow", "value": 5},
+                                    {"color": "red", "value": 15},
+                                ],
+                            },
+                        },
+                    ],
+                },
+            ],
+        },
+        "options": {"footer": {"show": False}, "sortBy": []},
+    })
+    pid += 1
+    y += 8
+
+    # ── Row 4: Entry Thresholds table ────────────────────────────────────────
+    threshold_sql = """
+SELECT
+  ticker                                              AS "Ticker",
+  pct_below                                           AS "% Below 52w High",
+  threshold_price                                     AS "Threshold Price",
+  latest_close                                        AS "Current Price",
+  gap_to_threshold_pct                                AS "Gap to Threshold %",
+  CASE WHEN is_at_or_below_threshold THEN '🟢 Signal' ELSE '⬜ Not Yet' END AS "Buy Signal"
+FROM mart_entry_thresholds
+ORDER BY ticker, pct_below
+"""
+    panels.append({
+        "id": pid, "type": "table",
+        "title": "Entry Point Thresholds (5 – 30% below 52w High)",
+        "gridPos": {"x": 0, "y": y, "w": 24, "h": 12},
+        "datasource": ds,
+        "targets": [_sql_target(threshold_sql)],
+        "fieldConfig": {
+            "defaults": {"custom": {"align": "auto"}},
+            "overrides": [
+                {
+                    "matcher": {"id": "byName", "options": "% Below 52w High"},
+                    "properties": [{"id": "unit", "value": "percent"}],
+                },
+                {
+                    "matcher": {"id": "byName", "options": "Gap to Threshold %"},
+                    "properties": [
+                        {"id": "unit", "value": "percent"},
+                        {"id": "custom.displayMode", "value": "color-text"},
+                        {
+                            "id": "thresholds",
+                            "value": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {"color": "green", "value": None},
+                                    {"color": "red", "value": 0},
+                                ],
+                            },
+                        },
+                    ],
+                },
+            ],
+        },
+        "options": {"footer": {"show": False}},
+    })
+
+    return {
+        "title": DASHBOARD_TITLE,
+        "uid": DASHBOARD_UID,
+        "tags": ["etf", "finance", "dbt", "portfolio"],
+        "schemaVersion": 38,
+        "version": 1,
+        "refresh": "1h",
+        "time": {"from": "now-1y", "to": "now"},
+        "timepicker": {},
+        "panels": panels,
+        "annotations": {"list": []},
+        "templating": {"list": []},
+        "links": [],
+        "graphTooltip": 1,
+        "fiscalYearStartMonth": 0,
+        "liveNow": False,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Push to Grafana
+# ---------------------------------------------------------------------------
+
+def push_dashboard(dashboard: dict) -> str:
+    result = _post(
+        "/api/dashboards/db",
+        {
+            "dashboard": dashboard,
+            "overwrite": True,
+            "message": "Provisioned by scripts/provision_grafana.py",
+        },
+    ).json()
+    return f"{GRAFANA_URL}{result.get('url', '/dashboards')}"
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    if not GRAFANA_URL or not GRAFANA_API_KEY:
+        print("❌  Set GRAFANA_URL and GRAFANA_API_KEY before running this script.")
+        print("    See analytics/docs/grafana_setup.md for instructions.")
+        sys.exit(1)
+
+    print(f"🔗  Grafana: {GRAFANA_URL}\n")
+
+    ds_uid = get_or_create_datasource()
+    dashboard = build_dashboard(ds_uid)
+
+    # Save JSON copy to grafana/ for version control + manual import
+    os.makedirs(os.path.dirname(os.path.abspath(GRAFANA_JSON_PATH)), exist_ok=True)
+    with open(GRAFANA_JSON_PATH, "w") as f:
+        json.dump(dashboard, f, indent=2)
+    print(f"💾  Dashboard JSON → grafana/etf_dashboard.json")
+
+    url = push_dashboard(dashboard)
+    print(f"✅  Dashboard live → {url}")
+    print("\nDone. GitHub Actions will keep your data fresh every weekday night.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What this delivers

Always-on ETF dashboard at a permanent Grafana URL. No server to manage, no credit card, no Docker to start. Data refreshes every weekday night automatically.

Replaces the Metabase + Oracle Cloud VM approach.

---

## New files

### `scripts/provision_grafana.py`

Idempotent Python script that provisions everything in Grafana via REST API:
1. Creates the PostgreSQL data source pointing to Supabase
2. Builds and pushes the full dashboard
3. Saves `grafana/etf_dashboard.json` for version control

**Dashboard panels:**
- 5 KPI stat cards — latest price (EUR) + daily Δ% per ETF, green/red background
- Price history time series — all 5 ETFs, EUR, with time picker (1d → all-time)
- 52-week metrics table — price, Δ%, 52w high/low, % below high (color-coded)
- Entry thresholds table — 5–30% levels with buy signal column (🟢 / ⬜)

### `analytics/docs/grafana_setup.md`

4-step guide, ~15 minutes, no card needed:
1. Create Grafana service account token
2. Add `GRAFANA_URL` + `GRAFANA_API_KEY` to GitHub Secrets
3. Run via GitHub Actions trigger (or locally)
4. Bookmark the permanent dashboard URL

## Updated files

### `production_automation.yml`

Added optional Grafana provisioning step at the end — runs only when both `GRAFANA_URL` and `GRAFANA_API_KEY` secrets are set. Silently skipped otherwise. No pipeline breakage.

### `README.md`

Stack table, pipeline description, and production setup updated to reflect Grafana Cloud.

---

## After merging — what to do

1. Add `GRAFANA_URL` and `GRAFANA_API_KEY` to GitHub Secrets (see guide)
2. Go to Actions → Production Market Data Automation → Run workflow
3. Bookmark the URL printed at the end of the run
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-64fcc1db-6cef-4360-a6e6-889b90a77a1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-64fcc1db-6cef-4360-a6e6-889b90a77a1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

