### PR TITLE
Set up development environment (AGENTS.md)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,31 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This repo is an ETF data-engineering pipeline: **Python ETL (yfinance) → PostgreSQL → dbt → static website dashboard** (Metabase/Airflow/Grafana are production/optional and need Docker, which is NOT available in this VM).
+
+### Environment layout
+- Python deps live in a virtualenv at `.venv` (created by the startup update script). Run tools with `.venv/bin/python`, `.venv/bin/dbt`, etc., or `source .venv/bin/activate`.
+- `black` is pinned to `24.10.0` on purpose: the latest `black` requires `pathspec>=1.0`, which conflicts with `dbt-core` (`pathspec<0.13`). Do not bump it without resolving that conflict.
+- Copy env vars before running anything: `cp .env.example .env` then `set -a && . ./.env && set +a`. Defaults point at the local Postgres below.
+
+### PostgreSQL (must be started manually each session)
+- PostgreSQL 16 is installed system-wide but is NOT auto-started on VM boot. Start it with:
+  `sudo pg_ctlcluster 16 main start`
+- The `etf_user` role (password `etf_pass`) and `etf_db` database already exist in the persisted cluster; connect with `PGPASSWORD=etf_pass psql -h localhost -U etf_user -d etf_db`.
+- If starting fresh, recreate them as the `postgres` superuser (role `etf_user` LOGIN PASSWORD `etf_pass`, then `createdb -O etf_user etf_db`).
+
+### Running the pipeline (end-to-end)
+1. Init schema + load reference symbols: `PYTHONPATH=. .venv/bin/python analytics/database/load_symbols.py`
+2. Fetch market data (needs internet; hits Yahoo Finance): `PYTHONPATH=. .venv/bin/python analytics/enhanced_workflow.py --step fetch`
+3. Build dbt models (run from `dbt/`, always pass `--profiles-dir .`): `dbt deps`, then `dbt run --profiles-dir .`, `dbt test --profiles-dir .`.
+4. Serve the website: `cd website && python3 -m http.server 8000` then open `http://localhost:8000/index.html`.
+
+### Tests / lint
+- CI health check (see `.github/workflows/test_automation.yml`): `PYTHONPATH=. .venv/bin/python analytics/test_enhanced_workflow.py` (needs Postgres running).
+- Lint tools are installed (`black`, `isort`, `flake8`) but the existing codebase is NOT formatted to their defaults, so they report many pre-existing style findings — that is expected, not a regression.
+
+### Known pre-existing bugs (do NOT assume these are environment issues)
+- `analytics/etl/enhanced_market_data_fetcher.calculate_and_store_metrics` raises `unsupported operand type(s) for *: 'decimal.Decimal' and 'float'` because Postgres returns `DECIMAL` columns as `Decimal`. Raw OHLCV price rows are still inserted before this fails, but the `fifty_two_week_metrics` / `decrease_thresholds` tables stay empty, so `mart_52week_metrics` and `mart_entry_thresholds` build with 0 rows (`mart_price_history` is unaffected).
+- `analytics/etl/data_exporter.py` uses SQLite-only syntax (`?` placeholders, `PRAGMA`) but the DB is Postgres, so `--step export` / website JSON export fails against the real DB.
+- `dbt source freshness --profiles-dir .` only succeeds for the `etf_data` source; the others have no `loaded_at_field` and error out by design on the Postgres adapter.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and validates the local development environment for the ETF data-engineering pipeline, and documents durable Cursor Cloud setup/run instructions in `AGENTS.md`.

The stack is **Python ETL (yfinance) → PostgreSQL → dbt → static website dashboard**. Metabase/Airflow/Grafana are production/optional and require Docker (not available in this VM), so they are out of scope for the dev environment.

## What was set up
- Installed PostgreSQL 16 (system dependency, persisted in the VM snapshot) with role `etf_user` / db `etf_db`.
- Created a Python virtualenv at `.venv` and installed `requirements.txt` plus dev tools (`pytest`, `black==24.10.0`, `isort`, `flake8`, `requests`). `black` is pinned to avoid a `pathspec` conflict with `dbt-core`.
- Added `AGENTS.md` with a `## Cursor Cloud specific instructions` section covering how to start Postgres, run the ETL + dbt, serve the website, run tests/lint, and a list of pre-existing bugs so future agents don't misdiagnose them.

The update script (venv + dependency install) is registered separately as the startup script.

## Verified end-to-end
- ✅ CI health check: `PYTHONPATH=. python analytics/test_enhanced_workflow.py` (4/4)
- ✅ ETL: loaded 5 ETFs (~1,152 rows each of real OHLCV, 2021–2026) + FX rates into Postgres
- ✅ dbt: `dbt run` (6 models, `mart_price_history` = 5,766 rows) and `dbt test` (41/41)
- ✅ Website dashboard served and exercised (ETF switch, currency EUR/USD, time-range)

## Walkthrough
[etf_dashboard_demo.mp4](https://cursor.com/agents/bc-3246e54d-4292-4a4c-ad02-8fdd24bbc28e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fetf_dashboard_demo.mp4)
Interactive ETF dashboard rendering real market data.

[VOO 1-year chart](https://cursor.com/agents/bc-3246e54d-4292-4a4c-ad02-8fdd24bbc28e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdashboard_voo_1year.webp)
[52-week metrics and entry points](https://cursor.com/agents/bc-3246e54d-4292-4a4c-ad02-8fdd24bbc28e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdashboard_52week_metrics.webp)

## Note (pre-existing bugs, not introduced here)
- `enhanced_market_data_fetcher.calculate_and_store_metrics` fails with `Decimal * float` on Postgres, leaving `mart_52week_metrics` / `mart_entry_thresholds` empty (raw prices + `mart_price_history` are unaffected).
- `data_exporter.py` uses SQLite-only syntax so website JSON export fails against Postgres.

These are documented in `AGENTS.md`; no application code was modified.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3246e54d-4292-4a4c-ad02-8fdd24bbc28e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3246e54d-4292-4a4c-ad02-8fdd24bbc28e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

