### PR TITLE
docs: replace v2 plan with v3 DuckDB-only cleanup + reporting roadmap

### DIFF
--- a/analytics/docs/stock-market-v2-reporting-layer.md
+++ b/analytics/docs/stock-market-v2-reporting-layer.md
@@ -1,246 +1,191 @@
-# Stock-Market v2 — Reporting Layer (Streamlit + DuckDB)
+# Stock-Market — Final Roadmap: Cleanup + Reporting Layer (v3, DuckDB-only)
 
 > **Status:** Approved direction — pending implementation
-> **Supersedes:** `stock-market-v1.md` (Metabase plan). That plan was never fully implemented;
-> production had already diverged to Grafana Cloud. This document is the single source of truth
-> for the reporting layer going forward.
-> **Goal:** A clean, cost-free, publicly accessible dashboard, visually matching
-> `assets/etf-dashboard-mockup.png`, without adding a hosted database server or another
-> partially-adopted visualization tool.
+> **Supersedes:** `stock-market-v1.md` (Metabase plan) AND the first version of this file
+> (dual Postgres+DuckDB design). This is the single, final source of truth.
+> **Goal:** A clean, single-environment, cost-free project that runs entirely in the cloud
+> with zero local intervention, ending in a public dashboard matching
+> `assets/etf-dashboard-mockup.png`.
 
 ---
 
-## 1. Why this supersedes v1
+## 0. Decision flagged for review
 
-The project has accumulated visualization approaches over time without formally retiring the
-previous one:
+**Airflow is recommended for full retirement, not just a modified task.** Reasoning:
 
-| Order | Tool | Status before this doc |
-|---|---|---|
-| 1 | Chart.js + GitHub Pages | Planned for archive in v1, never fully removed |
-| 2 | Metabase (OSS, Docker) | Planned in v1, not what's actually running in prod |
-| 3 | Grafana Cloud | Actually running in production today (per root `README.md`) |
-| 4 | Streamlit (this doc) | New, final direction |
+- Airflow has never run in production here — the README already states production uses
+  GitHub Actions "no Airflow server needed."
+- Airflow only runs if you manually start Docker Desktop and the containers — this directly
+  conflicts with "the project should run in the cloud without needing my intervention."
+- Keeping it means two parallel definitions of the same pipeline (the Airflow DAG and the
+  GitHub Actions workflow) — the exact kind of redundant setup this cleanup is meant to remove.
 
-This churn — not the database choice — was the main risk to keeping the project clean. This
-document exists to make Streamlit the **one** dashboard going forward and explicitly retire
-the rest, rather than adding a fifth tool alongside the others.
-
----
-
-## 2. What changes and why
-
-| Layer | Current | New |
-|---|---|---|
-| Production warehouse | PostgreSQL on Supabase (hosted, free tier) | **DuckDB file**, built by the pipeline, no server |
-| Local dev warehouse | PostgreSQL (Docker) | **Unchanged** — stays PostgreSQL in Docker |
-| dbt | Single target: `postgres` | **Two targets:** `dev` (postgres, local) and `prod` (duckdb, file-based) |
-| Orchestration (local) | Airflow (Docker) | **Unchanged** — stays functional, only the `visualize` task changes |
-| Orchestration (prod) | GitHub Actions (no Airflow) | **Unchanged** in structure, `visualize` step replaced |
-| Dashboard | Grafana Cloud (public dashboards, restricted/read-only mode) | **Streamlit app**, full custom design, genuinely public |
-| Hosting for dashboard | Grafana Cloud | **Streamlit Community Cloud** (free forever, non-commercial use) |
-| Static website | GitHub Pages (Chart.js, partially archived already) | **Archived** — Streamlit URL becomes the single public front door |
-
-### Why DuckDB instead of keeping Supabase for production
-
-- The dataset is small and low-write (5 ETFs, daily batch updates) — this is not a workload that
-  needs an always-on multi-user relational server.
-- Supabase's free tier **auto-pauses after ~7 days of inactivity** — an operational risk with no
-  upside for this use case.
-- DuckDB removes connection strings, server credentials, networking, and pause/wake failure modes
-  entirely. The pipeline produces a file; the dashboard reads a file.
-- `dbt-duckdb` uses the same dbt models (staging → intermediate → marts) with only the target
-  changed — no rewrite of SQL logic.
-
-### Why Airflow and local Postgres are explicitly kept
-
-- Airflow remains valuable for demonstrating/exercising real orchestration (DAGs, retries,
-  dependencies) in local development.
-- Local Postgres (Docker) is not a cost or stability concern — it never leaves your machine.
-- Only the **production data path** and the **visualize** step change. Nothing about local
-  development changes except one Airflow task's implementation.
+If you want to keep Airflow purely as a portfolio artifact demonstrating orchestration skills,
+that's reasonable — but it should live in `archive/` clearly marked "not part of the running
+system," not in the active project structure. This document assumes full retirement unless
+you say otherwise.
 
 ---
 
-## 3. New architecture
+## 1. Constraints for this design
+
+- Single environment — no dev/test/prod separation (solo developer)
+- No redundant tools — one database technology, one orchestrator, one dashboard tool
+- Zero local intervention required to keep the project running
+- Fully cost-free, indefinitely
+- End state: a public dashboard URL, matching the target mockup design
+
+---
+
+## 2. Audit of current repo state (grounded in what actually exists today)
+
+### Already known-obsolete per the project's own README
+
+The README's "What dbt replaces" table already documents these as superseded — they were
+never removed from the repo:
+
+| File | Superseded by |
+|---|---|
+| `analytics/etl/currency_converter_etl.py` | `dbt/models/intermediate/int_etf_eur.sql` |
+| `analytics/etl/data_exporter.py` (metric calc) | `dbt/models/marts/mart_52week_metrics.sql` |
+| `analytics/etl/data_exporter.py` (thresholds) | `dbt/models/marts/mart_entry_thresholds.sql` |
+
+### Additional dead/duplicate code found in this audit
+
+| File | Issue |
+|---|---|
+| `server_automation.py` (repo root) | v0 script: writes to SQLite, `git commit`s the DB file. Fully superseded by `production_automation.yml` (which uses Postgres/GitHub Actions, no git-committed DB) |
+| `.github/workflows/test_daily_update.yml` | Same v0 SQLite-commit pattern, runs on a stale `automation-daily-update` branch. Duplicate of `production_automation.yml` |
+| `analytics/etl/market_data_fetcher.py` | Superseded by `analytics/etl/enhanced_market_data_fetcher.py` (the one actually used by `enhanced_workflow.py`) |
+| `analytics/workflow.py` | Superseded by `analytics/enhanced_workflow.py` (the one actually used in all current workflows) |
+| `analytics/daily_automation.py` | Old automation entry point, not referenced by current GitHub Actions workflows |
+| `scripts/provision_grafana.py`, `scripts/oracle-cloud-init.yml` | Tied to Grafana/Oracle VM production dashboard — retired with this doc |
+| `analytics/docs/grafana_setup.md`, `metabase_setup.md`, `oracle-vm-setup.md` | Document retired infrastructure |
+
+### Confirmed still in active use — keep, adapt to DuckDB
+
+| File | Role |
+|---|---|
+| `analytics/enhanced_workflow.py` | Main ETL orchestrator, called by GitHub Actions |
+| `analytics/etl/enhanced_market_data_fetcher.py` | yfinance fetch logic |
+| `analytics/utils/currency_converter.py`, `validators.py` | Shared helpers used during extraction |
+| `analytics/database_diagnostic.py` | Status reporting, called by `production_automation.yml` — needs its Postgres queries adapted to DuckDB |
+| `analytics/test_enhanced_workflow.py` | Test suite, called by `test_automation.yml` |
+| `dbt/models/` (staging, intermediate, marts) | Core transformation logic — unchanged in content, only the target changes |
+| `airflow/`, `docker-compose.yml`, `docker-compose.prod.yml` | Retired per Section 0 |
+
+*(Docs not fully audited here — `architecture.md`, `automation_setup.md`, `how_to_run_scripts.md`,
+`setup.md`, `currency_conversion.md` — review each for overlap with the README during Phase 4
+and consolidate or archive as needed.)*
+
+---
+
+## 3. Final target architecture
 
 ```
-                    LOCAL DEVELOPMENT (unchanged)
-┌───────────────────────────────────────────────────────────────┐
-│  Apache Airflow (Docker) → PostgreSQL (Docker) → dbt (dev)      │
-│  DAG: etf_market_data_pipeline                                  │
-└───────────────────────────────────────────────────────────────┘
-
-                    PRODUCTION (changed)
-┌────────────────────────────────────────────────────────────────────┐
-│  GitHub Actions (daily, Mon–Fri 21:15 UTC)                           │
-│                                                                      │
-│  ┌──────────────┐  ┌──────────────┐  ┌─────────┐  ┌──────────┐      │
-│  │ Extract&Load │→ │  Transform   │→ │ Quality │→ │ Publish  │      │
-│  │ (yfinance →  │  │  dbt run     │  │ dbt test│  │ artifact │      │
-│  │  local .db   │  │  --target=   │  │ + source│  │ (DuckDB  │      │
-│  │  file)       │  │  duckdb      │  │freshness│  │  file)   │      │
-│  └──────────────┘  └──────────────┘  └─────────┘  └────┬─────┘      │
-└────────────────────────────────────────────────────────┼───────────┘
-                                                          │
-                                                          ▼
+                    SINGLE ENVIRONMENT — FULLY CLOUD-RUN
+┌──────────────────────────────────────────────────────────────────────┐
+│  GitHub Actions — one workflow, daily schedule (Mon–Fri 21:15 UTC)     │
+│  + workflow_dispatch for manual runs                                   │
+│                                                                        │
+│  ┌──────────────┐  ┌──────────────┐  ┌─────────┐  ┌────────────┐      │
+│  │ Extract&Load │→ │  Transform   │→ │ Quality │→ │  Publish   │      │
+│  │ yfinance →   │  │  dbt run     │  │dbt test │  │ warehouse. │      │
+│  │ local .duckdb│  │ (duckdb only)│  │+freshness│ │ duckdb →   │      │
+│  │ file         │  │              │  │         │  │ GH Release │      │
+│  └──────────────┘  └──────────────┘  └─────────┘  └─────┬──────┘      │
+└──────────────────────────────────────────────────────────────┼───────┘
+                                                                │
+                                                                ▼
                               GitHub Release asset (tag: latest-data)
                               warehouse.duckdb, overwritten daily
-                                                          │
-                                                          ▼
-                        ┌─────────────────────────────────────┐
-                        │  Streamlit app (Streamlit Cloud)     │
-                        │  downloads + caches warehouse.duckdb │
-                        │  renders ETF Analytics Dashboard     │
-                        │  Public URL, no login required       │
-                        └─────────────────────────────────────┘
+                                                                │
+                                                                ▼
+                              ┌───────────────────────────────┐
+                              │ Streamlit app (Streamlit Cloud)│
+                              │ downloads + caches the file    │
+                              │ ETF Analytics Dashboard        │
+                              │ Public URL, no login           │
+                              └───────────────────────────────┘
 ```
 
----
+**No local machine involvement at any point** — GitHub Actions runs the pipeline, Streamlit
+Cloud auto-redeploys from `git push` and serves the dashboard.
 
-## 4. dbt changes
-
-Add a second target to `dbt/profiles.yml`:
-
-```yaml
-etf_analytics:
-  target: dev
-  outputs:
-    dev:
-      type: postgres
-      host: "{{ env_var('DB_HOST', 'localhost') }}"
-      # ... existing local config, unchanged ...
-    prod:
-      type: duckdb
-      path: "{{ env_var('DUCKDB_PATH', 'warehouse.duckdb') }}"
-      threads: 4
-```
-
-- `dbt run --profiles-dir . --target dev` → local Postgres (Airflow/dev workflow, unchanged)
-- `dbt run --profiles-dir . --target prod` → builds `warehouse.duckdb` (used in GitHub Actions)
-
-**Known risk to validate during implementation:** dbt models must stay ANSI-SQL-compatible across
-both adapters. A few functions (date arithmetic, string functions) can differ slightly between
-Postgres and DuckDB — each mart model should be tested against both targets before this is
-considered done.
-
-Add `dbt-duckdb` and `duckdb` to `requirements.txt`.
+Optional local development (not required to run the project, purely a convenience for editing):
+`pip install -r requirements.txt && dbt run` — DuckDB needs no Docker, no server, just a
+local file. This is simpler than the old Postgres-in-Docker workflow, not an added burden.
 
 ---
 
-## 5. Airflow DAG changes
+## 4. Phase 0 — Cleanup (before adding anything new)
 
-Only the final stage changes:
+- [ ] Delete or move to `archive/`: `server_automation.py`, `analytics/workflow.py`,
+      `analytics/daily_automation.py`, `analytics/etl/market_data_fetcher.py`,
+      `analytics/etl/currency_converter_etl.py`, `analytics/etl/data_exporter.py`
+- [ ] Delete `.github/workflows/test_daily_update.yml`
+- [ ] Move `airflow/`, `docker-compose.yml`, `docker-compose.prod.yml` to `archive/`
+- [ ] Move `scripts/provision_grafana.py`, `scripts/oracle-cloud-init.yml` to `archive/`
+- [ ] Move `website/` (Chart.js, investment planner) to `archive/`
+- [ ] Delete `.github/workflows/deploy-website.yml`
+- [ ] Add "Superseded" banners to `stock-market-v1.md`, `grafana_setup.md`, `metabase_setup.md`,
+      `oracle-vm-setup.md`
+- [ ] Review `architecture.md`, `automation_setup.md`, `how_to_run_scripts.md`, `setup.md` for
+      overlap with README; consolidate or archive
 
-| Stage | Before | After |
+## 5. Phase 1 — dbt on DuckDB only
+
+- [ ] Update `dbt/profiles.yml` to a single `duckdb` target (remove postgres target entirely)
+- [ ] Replace `psycopg2-binary`, `dbt-postgres` with `duckdb`, `dbt-duckdb` in `requirements.txt`
+- [ ] Run all mart models against DuckDB, fix any dialect-specific SQL
+- [ ] Adapt `analytics/database_diagnostic.py` to query DuckDB instead of Postgres
+
+## 6. Phase 2 — One GitHub Actions workflow
+
+- [ ] Replace `production_automation.yml` with a single workflow: extract → dbt run → dbt test →
+      publish `warehouse.duckdb` as a GitHub Release asset (`gh release upload --clobber`)
+- [ ] Remove `DATABASE_URL`/Supabase parsing and the Grafana provisioning step
+- [ ] Simplify `test_automation.yml`: remove the Postgres service container (no longer needed —
+      tests run against an ephemeral local DuckDB file)
+
+## 7. Phase 3 — Streamlit dashboard
+
+- [ ] New `dashboard/app.py` + `.streamlit/config.toml` (dark theme)
+- [ ] Downloads `warehouse.duckdb` from the GitHub Release URL, cached via `st.cache_data`
+- [ ] KPI cards, price history chart (Plotly `rangeselector`), threshold bars, summary table —
+      per the mockup, reading `mart_price_history`, `mart_52week_metrics`, `mart_entry_thresholds`
+- [ ] Deploy via Streamlit Community Cloud, connected to this repo, auto-redeploy on push
+
+## 8. Phase 4 — Documentation
+
+- [ ] Update root `README.md`: architecture diagram, tech stack table, dashboard link
+- [ ] Consolidate `analytics/docs/` — one clear doc per remaining concern, delete/archive the rest
+
+---
+
+## 9. Cost and stability summary
+
+| Component | Cost | Runs where |
 |---|---|---|
-| `extract_load` | Unchanged | Unchanged |
-| `transform` | Unchanged | Unchanged |
-| `quality` | Unchanged | Unchanged |
-| `visualize` | `provision_grafana` (Grafana REST API) | `publish_duckdb_artifact` (builds `--target duckdb`, no external API needed for local runs; local runs can skip publishing) |
+| GitHub Actions | Free | Cloud |
+| DuckDB build | Free | Inside the GitHub Actions run |
+| GitHub Release storage | Free | Cloud |
+| Streamlit Community Cloud | Free forever (non-commercial use) | Cloud |
 
-The DAG keeps its 4-stage shape. Locally, the last stage can simply confirm the DuckDB file built
-successfully — publishing to a GitHub Release is a production-only concern, handled in GitHub
-Actions, not required for local Airflow runs.
+No server, no database service, no VM, nothing requiring your machine to be on.
 
 ---
 
-## 6. Production GitHub Actions changes (`production_automation.yml`)
+## 10. Definition of done
 
-Add steps after the existing `dbt run`:
-
-- `dbt run --profiles-dir dbt --target prod` (builds `warehouse.duckdb`)
-- `dbt test --profiles-dir dbt --target prod`
-- Publish `warehouse.duckdb` as a GitHub Release asset under a fixed tag (e.g. `latest-data`),
-  overwriting the previous asset each run (use `gh release upload --clobber` or equivalent action)
-
-Remove: the Supabase `DATABASE_URL` write step and the Grafana provisioning step for production
-runs (kept only if you want to dual-run during a transition period — see Section 8).
+- [ ] `main` branch has no references to Postgres, Supabase, Grafana, Metabase-in-production,
+      or Airflow-in-production
+- [ ] One GitHub Actions workflow runs the entire pipeline daily, unattended
+- [ ] A public Streamlit URL displays the ETF Analytics Dashboard, matching the mockup design,
+      viewable by anyone with no login
+- [ ] You can delete this repo from your local machine entirely and the live dashboard keeps
+      updating daily without any action from you
 
 ---
 
-## 7. Streamlit dashboard design
-
-Reads `warehouse.duckdb` (downloaded from the GitHub Release URL, cached with `st.cache_data`, TTL
-matched to the daily pipeline schedule so it refreshes once/day without re-downloading on every
-visitor).
-
-Mapped directly from `assets/etf-dashboard-mockup.png`:
-
-| Mockup panel | Streamlit / Plotly implementation |
-|---|---|
-| Dark theme | `.streamlit/config.toml` — dark base + custom accent colors |
-| 5 KPI cards (ticker, price, % change, sparkline) | `st.columns(5)` + `st.metric()` per ETF + small Plotly sparkline |
-| Price history chart, 1M/3M/1Y/2Y/ALL buttons | Plotly `go.Figure` with native `rangeselector` buttons |
-| Entry point thresholds (horizontal bars) | Plotly horizontal bar chart, one bar per threshold level |
-| 52-week summary table | `st.dataframe()` with conditional red/green formatting |
-
-Data source: `mart_price_history`, `mart_52week_metrics`, `mart_entry_thresholds` — same marts
-already defined in `dbt/models/marts/`, unchanged.
-
----
-
-## 8. What gets archived
-
-| Item | Action |
-|---|---|
-| Grafana Cloud dashboard + provisioning | Archive. Keep `analytics/docs/grafana_setup.md` but mark superseded at the top of the file |
-| `docker-compose.prod.yml` (Oracle Cloud VM, Metabase) | Archive — no VM/Metabase needed once Streamlit Cloud hosts the dashboard |
-| Supabase production database | Archive — production data now lives in the published DuckDB file, not a hosted DB |
-| `website/` (GitHub Pages, Chart.js, investment planner) | Archive fully — Streamlit's public URL becomes the single front door. Update root `README.md` to link to it |
-| `.github/workflows/deploy-website.yml` | Remove or archive alongside `website/` |
-| `stock-market-v1.md` | Mark superseded at the top, keep for history, do not delete |
-
----
-
-## 9. What is explicitly NOT changed
-
-- Local Docker Compose (`docker-compose.yml`): PostgreSQL + Metabase for local dev — unchanged
-  (Metabase can stay as a local exploration tool if useful; it's just not the production dashboard)
-- Airflow DAG structure and local dev workflow — unchanged except the final stage's implementation
-- `dbt/models/` staging and intermediate layers — unchanged
-- Data extraction (yfinance) logic — unchanged
-
----
-
-## 10. Cost and stability summary
-
-| Component | Cost | Notes |
-|---|---|---|
-| GitHub Actions | Free | Public repo — unlimited minutes |
-| DuckDB file build | Free | No server, no hosting |
-| GitHub Release (data storage) | Free | Well within GitHub's storage limits for a small file |
-| Streamlit Community Cloud | Free forever | Non-commercial use, ~1GB RAM, sleeps after ~12h idle |
-| Local Postgres/Airflow/Metabase | Free | Docker, local machine only |
-
-No component in this design has a trial period, a renewal requirement, or a usage-based billing risk.
-
----
-
-## 11. Implementation checklist
-
-### Phase A — dbt DuckDB target
-- [ ] Add `prod` target (DuckDB) to `dbt/profiles.yml`
-- [ ] Add `dbt-duckdb`, `duckdb` to `requirements.txt`
-- [ ] Run all mart models against `--target prod` locally, fix any dialect-specific SQL
-
-### Phase B — Production pipeline
-- [ ] Update `production_automation.yml`: build DuckDB file, run tests, publish as Release asset
-- [ ] Remove Supabase `DATABASE_URL` write and Grafana provisioning from the production workflow
-
-### Phase C — Airflow
-- [ ] Replace `provision_grafana` task with `publish_duckdb_artifact` (or a local-only build
-      confirmation step) in `airflow/dags/etf_pipeline.py`
-
-### Phase D — Streamlit app
-- [ ] New `dashboard/` folder: `app.py`, `requirements.txt`, `.streamlit/config.toml`
-- [ ] Implement KPI cards, price history chart, threshold bars, summary table per Section 7
-- [ ] Deploy via Streamlit Community Cloud, connect to this GitHub repo
-
-### Phase E — Archive
-- [ ] Move `website/`, `docker-compose.prod.yml` to an `archive/` folder (or a clearly marked git
-      tag/branch) — do not silently delete history
-- [ ] Add "Superseded by `stock-market-v2-reporting-layer.md`" banner to `stock-market-v1.md`
-- [ ] Add "Superseded" banner to `grafana_setup.md`
-- [ ] Update root `README.md`: architecture diagram, tech stack table, and the public dashboard
-      link now point to Streamlit
+*Documentation written for review. Implementation begins only after approval.*


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Replaces the full content of `analytics/docs/stock-market-v2-reporting-layer.md` with the final v3 roadmap: **Cleanup + Reporting Layer (DuckDB-only)**. Documentation only — no code implemented.

This version supersedes both `stock-market-v1.md` and the previous (dual Postgres+DuckDB) version of this file, and becomes the single, final source of truth. Key differences from the prior version:
- **DuckDB-only** for both build and (optional) local dev — the dual Postgres+DuckDB target design is dropped.
- **Airflow flagged for full retirement** (Section 0), not just a modified task.
- Adds a **repo audit** of dead/duplicate code and a **Phase 0 cleanup** step before any new work.
- Single GitHub Actions workflow → publishes `warehouse.duckdb` as a Release asset → Streamlit Community Cloud dashboard.
- Explicit **Definition of done** centered on zero local intervention.

## Notes
- Created on a dedicated branch off the latest `main` (not committed to `main`).
- No implementation performed, per request.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3246e54d-4292-4a4c-ad02-8fdd24bbc28e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3246e54d-4292-4a4c-ad02-8fdd24bbc28e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

