### PR TITLE
Phase 1: migrate warehouse to DuckDB (single-file, no server)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,13 +1,9 @@
-# PostgreSQL connection — used by Python ETL and dbt
-# For local Docker setup (docker compose up), the defaults below work as-is.
-# For production (hosted DB on Supabase / Neon / etc.), set DATABASE_URL only.
-
-# Single connection string (takes priority over individual vars)
-DATABASE_URL=postgresql://etf_user:etf_pass@localhost:5432/etf_db
-
-# Individual vars (used by dbt profiles.yml and as fallback for Python)
-DB_HOST=localhost
-DB_PORT=5432
-DB_USER=etf_user
-DB_PASSWORD=etf_pass
-DB_NAME=etf_db
+# DuckDB warehouse — used by the Python ETL and dbt.
+# The pipeline builds a single DuckDB file; there is no database server.
+#
+# By default the warehouse lives at `warehouse.duckdb` in the repo root (the ETL
+# runs from the root; dbt runs from `dbt/` and uses `../warehouse.duckdb`).
+# Only set DUCKDB_PATH if you want a custom location — and if you do, use an
+# ABSOLUTE path so the ETL and dbt agree on the same file.
+#
+# DUCKDB_PATH=/absolute/path/to/warehouse.duckdb

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,8 @@ wheels/
 # Database
 *.db
 *.sqlite3
+*.duckdb
+*.duckdb.wal
 
 # Logs
 *.log

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,31 +2,26 @@
 
 ## Cursor Cloud specific instructions
 
-This repo is an ETF data-engineering pipeline: **Python ETL (yfinance) → PostgreSQL → dbt** (marts consumed downstream). Reporting is mid-migration: the v3 roadmap (`analytics/docs/stock-market-v2-reporting-layer.md`) is moving to a DuckDB file + Streamlit dashboard. Airflow, Metabase, Grafana, the Chart.js `website/`, and legacy ETL scripts have been retired to `archive/` (Phase 0) and are NOT part of the running system.
+This repo is an ETF data-engineering pipeline: **Python ETL (yfinance) → DuckDB (single file) → dbt** (marts consumed downstream). Reporting is mid-migration per the v3 roadmap (`analytics/docs/stock-market-v2-reporting-layer.md`): the reporting layer will be a Streamlit dashboard reading the DuckDB file. Airflow, Metabase, Grafana, the Chart.js `website/`, and legacy ETL scripts have been retired to `archive/` and are NOT part of the running system.
 
 ### Environment layout
 - Python deps live in a virtualenv at `.venv` (created by the startup update script). Run tools with `.venv/bin/python`, `.venv/bin/dbt`, etc., or `source .venv/bin/activate`.
 - `black` is pinned to `24.10.0` on purpose: the latest `black` requires `pathspec>=1.0`, which conflicts with `dbt-core` (`pathspec<0.13`). Do not bump it without resolving that conflict.
-- Copy env vars before running anything: `cp .env.example .env` then `set -a && . ./.env && set +a`. Defaults point at the local Postgres below.
+- No database server is required (Phase 1 migrated off PostgreSQL). The warehouse is a single DuckDB file at `warehouse.duckdb` in the repo root, created by the pipeline. `.env` is optional; only set `DUCKDB_PATH` (absolute path) if you want a non-default location — the ETL and dbt must point at the same file.
 
-### PostgreSQL (must be started manually each session)
-- PostgreSQL 16 is installed system-wide but is NOT auto-started on VM boot. Start it with:
-  `sudo pg_ctlcluster 16 main start`
-- The `etf_user` role (password `etf_pass`) and `etf_db` database already exist in the persisted cluster; connect with `PGPASSWORD=etf_pass psql -h localhost -U etf_user -d etf_db`.
-- If starting fresh, recreate them as the `postgres` superuser (role `etf_user` LOGIN PASSWORD `etf_pass`, then `createdb -O etf_user etf_db`).
+### DuckDB path gotcha
+- The ETL runs from the repo root, so it defaults to `./warehouse.duckdb`. dbt runs from `dbt/`, so its profile defaults to `../warehouse.duckdb` — both resolve to the same repo-root file. If you override `DUCKDB_PATH`, use an absolute path or the two will diverge.
+- DuckDB allows only one read-write connection to the file at a time. Don't run the ETL and dbt concurrently against the same file (the workflow runs them sequentially).
 
 ### Running the pipeline (end-to-end)
-1. Init schema + load reference symbols: `PYTHONPATH=. .venv/bin/python analytics/database/load_symbols.py`
-2. Fetch market data (needs internet; hits Yahoo Finance): `PYTHONPATH=. .venv/bin/python analytics/enhanced_workflow.py --step fetch`
-3. Build dbt models (run from `dbt/`, always pass `--profiles-dir .`): `dbt deps`, then `dbt run --profiles-dir .`, `dbt test --profiles-dir .`.
-
-Note: `enhanced_workflow.py` now supports only `--step full|incremental|fetch` (the `currency`/`export` steps were archived with `analytics/etl/currency_converter_etl.py` and `data_exporter.py`). The old Chart.js site is at `archive/website/` for reference; the replacement Streamlit dashboard is not built yet (Phase 3).
+1. Full ETL (creates schema, loads symbols, fetches from Yahoo Finance — needs internet): `PYTHONPATH=. .venv/bin/python analytics/enhanced_workflow.py --step full`. Use `--step incremental` afterwards for daily top-ups. `--step full|incremental|fetch` are the only options; note `load_symbols.py` alone does NOT create the schema, so a fresh DB must be initialized via `--step full` (or `analytics/database/init_db.py`) first.
+2. Build dbt models (run from `dbt/`, always pass `--profiles-dir .`): `dbt deps`, then `dbt run --profiles-dir .`, `dbt test --profiles-dir .`. All 6 models build and the 41 data tests pass, including `mart_52week_metrics` and `mart_entry_thresholds` (now populated).
 
 ### Tests / lint
-- CI health check (see `.github/workflows/test_automation.yml`): `PYTHONPATH=. .venv/bin/python analytics/test_enhanced_workflow.py` (needs Postgres running).
+- CI health check (see `.github/workflows/test_automation.yml`): `PYTHONPATH=. .venv/bin/python analytics/test_enhanced_workflow.py`. No DB server needed — it creates/uses the DuckDB file.
 - Lint tools are installed (`black`, `isort`, `flake8`) but the existing codebase is NOT formatted to their defaults, so they report many pre-existing style findings — that is expected, not a regression.
 
-### Known pre-existing bugs (do NOT assume these are environment issues)
-- `analytics/etl/enhanced_market_data_fetcher.calculate_and_store_metrics` raises `unsupported operand type(s) for *: 'decimal.Decimal' and 'float'` because Postgres returns `DECIMAL` columns as `Decimal`. Raw OHLCV price rows are still inserted before this fails, but the `fifty_two_week_metrics` / `decrease_thresholds` tables stay empty, so `mart_52week_metrics` and `mart_entry_thresholds` build with 0 rows (`mart_price_history` is unaffected).
-- `dbt source freshness --profiles-dir .` only succeeds for the `etf_data` source; the others have no `loaded_at_field` and error out by design on the Postgres adapter.
-- (Historical, now archived) `archive/analytics/etl/data_exporter.py` uses SQLite-only syntax against a Postgres DB — do not resurrect it as-is; the DuckDB/Streamlit path replaces it.
+### Notes / caveats
+- `dbt source freshness --profiles-dir .` only computes for the `etf_data` source (it has a `loaded_at_field`); the other sources have none and error by design on the DuckDB adapter.
+- The GitHub Actions workflows (`production_automation.yml`, `test_automation.yml`) still assume PostgreSQL and are pending the Phase 2 rewrite; they are inconsistent with the DuckDB pipeline until then.
+- (Historical, archived) `archive/analytics/etl/data_exporter.py` used SQLite-only syntax — do not resurrect it as-is; the DuckDB/Streamlit path replaces it.

--- a/analytics/database/db_manager.py
+++ b/analytics/database/db_manager.py
@@ -1,49 +1,53 @@
-"""Database manager for ETF analytics."""
+"""Database manager for ETF analytics (DuckDB single-file warehouse)."""
 
 import os
-import psycopg2
 from datetime import datetime, date
+from pathlib import Path
 from typing import List, Dict, Any, Optional
 import pandas as pd
 import logging
 
+import duckdb
+
 logger = logging.getLogger(__name__)
 
 
-def _build_database_url() -> str:
-    """Build the PostgreSQL connection URL from environment variables."""
-    url = os.environ.get("DATABASE_URL")
-    if url:
-        return url
-    host = os.environ.get("DB_HOST", "localhost")
-    port = os.environ.get("DB_PORT", "5432")
-    user = os.environ.get("DB_USER", "etf_user")
-    password = os.environ.get("DB_PASSWORD", "etf_pass")
-    dbname = os.environ.get("DB_NAME", "etf_db")
-    return f"postgresql://{user}:{password}@{host}:{port}/{dbname}"
+def _build_duckdb_path() -> str:
+    """Resolve the DuckDB warehouse file path.
+
+    Honours DUCKDB_PATH when set (use an absolute path to stay consistent across
+    the Python ETL and dbt). Otherwise defaults to `warehouse.duckdb` at the repo
+    root so the ETL (run from the root) and dbt (run from `dbt/`, using
+    `../warehouse.duckdb`) resolve to the same file.
+    """
+    path = os.environ.get("DUCKDB_PATH")
+    if path:
+        return path
+    return str(Path(__file__).resolve().parents[2] / "warehouse.duckdb")
 
 
 class DatabaseManager:
-    def __init__(self, database_url: str = None):
-        """Initialize with a PostgreSQL connection URL."""
-        self.database_url = database_url or _build_database_url()
+    def __init__(self, db_path: str = None):
+        """Initialize with a DuckDB file path."""
+        self.db_path = db_path or _build_duckdb_path()
         self.conn = None
         self.cursor = None
 
     def connect(self):
         """Open a database connection."""
         try:
-            if self.conn is None or self.conn.closed:
-                self.conn = psycopg2.connect(self.database_url)
-                self.cursor = self.conn.cursor()
-        except psycopg2.Error as e:
+            if self.conn is None:
+                self.conn = duckdb.connect(self.db_path)
+                # DuckDB's connection object doubles as the cursor.
+                self.cursor = self.conn
+        except duckdb.Error as e:
             logger.error(f"Error connecting to database: {e}")
             raise
 
     def disconnect(self):
         """Close the database connection."""
         try:
-            if self.conn and not self.conn.closed:
+            if self.conn is not None:
                 self.conn.close()
         finally:
             self.conn = None
@@ -56,14 +60,14 @@ class DatabaseManager:
             with open(schema_path, "r") as f:
                 schema = f.read()
             self.connect()
-            # psycopg2 does not support executescript; run each statement separately
+            # DuckDB executes one statement per call; run them separately.
             statements = [s.strip() for s in schema.split(";") if s.strip()]
             for stmt in statements:
                 self.cursor.execute(stmt)
             self.conn.commit()
             logger.info("Database initialized successfully")
             print("Database initialized successfully")
-        except (psycopg2.Error, IOError) as e:
+        except (duckdb.Error, IOError) as e:
             logger.error(f"Error initializing database: {e}")
             raise
         finally:
@@ -79,14 +83,14 @@ class DatabaseManager:
                 """
                 SELECT date, open, high, low, close, volume
                 FROM etf_data
-                WHERE symbol_id = %s AND date BETWEEN %s AND %s
+                WHERE symbol_id = ? AND date BETWEEN ? AND ?
                 ORDER BY date
             """,
                 (symbol_id, start_date, end_date),
             )
             columns = ["date", "open", "high", "low", "close", "volume"]
             return [dict(zip(columns, row)) for row in self.cursor.fetchall()]
-        except psycopg2.Error as e:
+        except duckdb.Error as e:
             logger.error(f"Error getting market data: {e}")
             raise
         finally:
@@ -106,7 +110,7 @@ class DatabaseManager:
             )
             columns = ["id", "isin", "ticker", "name", "asset_type", "exchange", "currency"]
             return [dict(zip(columns, row)) for row in self.cursor.fetchall()]
-        except psycopg2.Error as e:
+        except duckdb.Error as e:
             logger.error(f"Error getting active symbols: {e}")
             raise
         finally:
@@ -120,7 +124,7 @@ class DatabaseManager:
                 """
                 SELECT id, isin, ticker, name, asset_type, exchange, currency, is_active
                 FROM symbols
-                WHERE isin = %s
+                WHERE isin = ?
             """,
                 (isin,),
             )
@@ -133,7 +137,7 @@ class DatabaseManager:
                     row,
                 )
             )
-        except psycopg2.Error as e:
+        except duckdb.Error as e:
             logger.error(f"Error getting symbol by ISIN: {e}")
             raise
         finally:
@@ -154,7 +158,7 @@ class DatabaseManager:
             self.cursor.execute(
                 """
                 INSERT INTO symbols (isin, ticker, name, asset_type, exchange, currency)
-                VALUES (%s, %s, %s, %s, %s, %s)
+                VALUES (?, ?, ?, ?, ?, ?)
                 RETURNING id
             """,
                 (isin, ticker, name, asset_type, exchange, currency),
@@ -162,7 +166,7 @@ class DatabaseManager:
             symbol_id = self.cursor.fetchone()[0]
             self.conn.commit()
             return symbol_id
-        except psycopg2.Error as e:
+        except duckdb.Error as e:
             logger.error(f"Error adding symbol: {e}")
             raise
         finally:
@@ -174,7 +178,7 @@ class DatabaseManager:
             self.connect()
             self.cursor.execute("DELETE FROM symbols")
             self.conn.commit()
-        except psycopg2.Error as e:
+        except duckdb.Error as e:
             logger.error(f"Error clearing symbols: {e}")
             raise
         finally:
@@ -186,8 +190,11 @@ class DatabaseManager:
             from analytics.utils.currency_converter import CurrencyConverter
 
             converter = CurrencyConverter()
-            self.connect()
 
+            # Build the payload first (no DB connection needed yet). Currency
+            # conversion opens its own DuckDB connection to cache FX rates, so it
+            # must run BEFORE we open the writer connection — DuckDB allows only
+            # one read-write connection to a file at a time.
             price_data_list = []
             for index, row in data.iterrows():
                 price_data_list.append(
@@ -205,13 +212,14 @@ class DatabaseManager:
                 logger.info(f"Converting {len(price_data_list)} records from {currency} to EUR")
                 price_data_list = converter.convert_price_data_batch(price_data_list, currency)
 
+            self.connect()
             for price_data in price_data_list:
                 self.cursor.execute(
                     """
                     INSERT INTO etf_data
                         (symbol_id, date, open, high, low, close, volume,
                          open_eur, high_eur, low_eur, close_eur)
-                    VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     ON CONFLICT (symbol_id, date) DO UPDATE SET
                         open        = EXCLUDED.open,
                         high        = EXCLUDED.high,
@@ -241,7 +249,7 @@ class DatabaseManager:
             self.conn.commit()
             logger.info(f"Inserted {len(price_data_list)} records for symbol {symbol_id}")
 
-        except psycopg2.Error as e:
+        except duckdb.Error as e:
             logger.error(f"Error inserting market data: {e}")
             raise
         finally:
@@ -264,7 +272,7 @@ class DatabaseManager:
                 """
                 INSERT INTO fifty_two_week_metrics
                     (symbol_id, calculation_date, high_52week, low_52week, high_date, low_date)
-                VALUES (%s, %s, %s, %s, %s, %s)
+                VALUES (?, ?, ?, ?, ?, ?)
                 ON CONFLICT (symbol_id, calculation_date) DO UPDATE SET
                     high_52week = EXCLUDED.high_52week,
                     low_52week  = EXCLUDED.low_52week,
@@ -289,7 +297,7 @@ class DatabaseManager:
                     (symbol_id, calculation_date, high_52week_price,
                      decrease_5_price, decrease_10_price, decrease_15_price,
                      decrease_20_price, decrease_25_price, decrease_30_price)
-                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
                 ON CONFLICT (symbol_id, calculation_date) DO UPDATE SET
                     high_52week_price  = EXCLUDED.high_52week_price,
                     decrease_5_price   = EXCLUDED.decrease_5_price,
@@ -315,7 +323,7 @@ class DatabaseManager:
             self.conn.commit()
             logger.info(f"Stored metrics and thresholds for symbol {symbol_id}")
 
-        except psycopg2.Error as e:
+        except duckdb.Error as e:
             logger.error(f"Error storing metrics: {e}")
             raise
         finally:

--- a/analytics/database/init_db.py
+++ b/analytics/database/init_db.py
@@ -4,7 +4,7 @@ from analytics.database.db_manager import DatabaseManager
 
 
 def main():
-    """Initialize the PostgreSQL database with tables."""
+    """Initialize the DuckDB warehouse with tables."""
     print("Initializing database...")
     db = DatabaseManager()
     db.initialize_database()

--- a/analytics/database/schema.sql
+++ b/analytics/database/schema.sql
@@ -1,6 +1,17 @@
+-- DuckDB schema for the ETF analytics warehouse.
+-- Numeric price/rate columns use DOUBLE (not DECIMAL) so the Python layer receives
+-- native floats, keeping arithmetic (e.g. 52-week threshold math) type-safe.
+
+-- Sequences backing the surrogate primary keys (DuckDB has no SERIAL keyword)
+CREATE SEQUENCE IF NOT EXISTS seq_symbols_id START 1;
+CREATE SEQUENCE IF NOT EXISTS seq_currency_rates_id START 1;
+CREATE SEQUENCE IF NOT EXISTS seq_etf_data_id START 1;
+CREATE SEQUENCE IF NOT EXISTS seq_fifty_two_week_metrics_id START 1;
+CREATE SEQUENCE IF NOT EXISTS seq_decrease_thresholds_id START 1;
+
 -- ETF/Stock symbols mapping table
 CREATE TABLE IF NOT EXISTS symbols (
-    id SERIAL PRIMARY KEY,
+    id INTEGER PRIMARY KEY DEFAULT nextval('seq_symbols_id'),
     isin TEXT NOT NULL UNIQUE,
     ticker TEXT NOT NULL,
     name TEXT NOT NULL UNIQUE,
@@ -13,29 +24,29 @@ CREATE TABLE IF NOT EXISTS symbols (
 
 -- Currency exchange rates table for historical rates
 CREATE TABLE IF NOT EXISTS currency_rates (
-    id SERIAL PRIMARY KEY,
+    id INTEGER PRIMARY KEY DEFAULT nextval('seq_currency_rates_id'),
     from_currency TEXT NOT NULL,
     to_currency TEXT NOT NULL,
     rate_date DATE NOT NULL,
-    exchange_rate DECIMAL(10,6) NOT NULL,
+    exchange_rate DOUBLE NOT NULL,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     UNIQUE(from_currency, to_currency, rate_date)
 );
 
 -- ETF data table to store historical price data
 CREATE TABLE IF NOT EXISTS etf_data (
-    id SERIAL PRIMARY KEY,
+    id INTEGER PRIMARY KEY DEFAULT nextval('seq_etf_data_id'),
     symbol_id INTEGER NOT NULL,
     date DATE NOT NULL,
-    open DECIMAL(10,2),
-    high DECIMAL(10,2),
-    low DECIMAL(10,2),
-    close DECIMAL(10,2),
+    open DOUBLE,
+    high DOUBLE,
+    low DOUBLE,
+    close DOUBLE,
     volume BIGINT,
-    open_eur DECIMAL(10,2),
-    high_eur DECIMAL(10,2),
-    low_eur DECIMAL(10,2),
-    close_eur DECIMAL(10,2),
+    open_eur DOUBLE,
+    high_eur DOUBLE,
+    low_eur DOUBLE,
+    close_eur DOUBLE,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY(symbol_id) REFERENCES symbols(id),
     UNIQUE(symbol_id, date)
@@ -43,11 +54,11 @@ CREATE TABLE IF NOT EXISTS etf_data (
 
 -- 52-week metrics table
 CREATE TABLE IF NOT EXISTS fifty_two_week_metrics (
-    id SERIAL PRIMARY KEY,
+    id INTEGER PRIMARY KEY DEFAULT nextval('seq_fifty_two_week_metrics_id'),
     symbol_id INTEGER NOT NULL,
     calculation_date DATE NOT NULL,
-    high_52week DECIMAL(10,2),
-    low_52week DECIMAL(10,2),
+    high_52week DOUBLE,
+    low_52week DOUBLE,
     high_date DATE,
     low_date DATE,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
@@ -57,16 +68,16 @@ CREATE TABLE IF NOT EXISTS fifty_two_week_metrics (
 
 -- Decrease thresholds tracking table
 CREATE TABLE IF NOT EXISTS decrease_thresholds (
-    id SERIAL PRIMARY KEY,
+    id INTEGER PRIMARY KEY DEFAULT nextval('seq_decrease_thresholds_id'),
     symbol_id INTEGER NOT NULL,
     calculation_date DATE NOT NULL,
-    high_52week_price DECIMAL(10,2),
-    decrease_5_price DECIMAL(10,2),
-    decrease_10_price DECIMAL(10,2),
-    decrease_15_price DECIMAL(10,2),
-    decrease_20_price DECIMAL(10,2),
-    decrease_25_price DECIMAL(10,2),
-    decrease_30_price DECIMAL(10,2),
+    high_52week_price DOUBLE,
+    decrease_5_price DOUBLE,
+    decrease_10_price DOUBLE,
+    decrease_15_price DOUBLE,
+    decrease_20_price DOUBLE,
+    decrease_25_price DOUBLE,
+    decrease_30_price DOUBLE,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY(symbol_id) REFERENCES symbols(id),
     UNIQUE(symbol_id, calculation_date)

--- a/analytics/utils/currency_converter.py
+++ b/analytics/utils/currency_converter.py
@@ -8,32 +8,29 @@ USD and GBP prices to EUR for European market analysis.
 
 import yfinance as yf
 from datetime import datetime, date, timedelta
+from pathlib import Path
 from typing import Optional, Dict, Any, List
 import logging
 import os
 
-import psycopg2
+import duckdb
 
 logger = logging.getLogger(__name__)
 
 
-def _build_database_url() -> str:
-    url = os.environ.get("DATABASE_URL")
-    if url:
-        return url
-    host = os.environ.get("DB_HOST", "localhost")
-    port = os.environ.get("DB_PORT", "5432")
-    user = os.environ.get("DB_USER", "etf_user")
-    password = os.environ.get("DB_PASSWORD", "etf_pass")
-    dbname = os.environ.get("DB_NAME", "etf_db")
-    return f"postgresql://{user}:{password}@{host}:{port}/{dbname}"
+def _build_duckdb_path() -> str:
+    """Resolve the DuckDB warehouse path (mirrors database.db_manager)."""
+    path = os.environ.get("DUCKDB_PATH")
+    if path:
+        return path
+    return str(Path(__file__).resolve().parents[2] / "warehouse.duckdb")
 
 
 class CurrencyConverter:
     """Handles currency conversions for ETF data with historical rate support."""
 
     def __init__(self, db_path: str = None):
-        self.database_url = _build_database_url()
+        self.db_path = db_path or _build_duckdb_path()
         self.exchange_rates = {}
         self.last_update = None
     
@@ -95,13 +92,12 @@ class CurrencyConverter:
         """Store exchange rates in the database."""
         conn = None
         try:
-            conn = psycopg2.connect(self.database_url)
-            cursor = conn.cursor()
+            conn = duckdb.connect(self.db_path)
             for date_str, rate in rates.items():
-                cursor.execute(
+                conn.execute(
                     """
                     INSERT INTO currency_rates (from_currency, to_currency, rate_date, exchange_rate)
-                    VALUES (%s, %s, %s, %s)
+                    VALUES (?, ?, ?, ?)
                     ON CONFLICT (from_currency, to_currency, rate_date)
                     DO UPDATE SET exchange_rate = EXCLUDED.exchange_rate
                     """,
@@ -109,32 +105,30 @@ class CurrencyConverter:
                 )
             conn.commit()
             logger.info(f"Stored {len(rates)} exchange rates for {from_currency}/{to_currency}")
-        except psycopg2.Error as e:
+        except duckdb.Error as e:
             logger.error(f"Error storing exchange rates: {e}")
         finally:
-            if conn and not conn.closed:
+            if conn is not None:
                 conn.close()
     
     def get_cached_exchange_rate(self, from_currency: str, to_currency: str, target_date: date) -> Optional[float]:
         """Get exchange rate from database cache."""
         conn = None
         try:
-            conn = psycopg2.connect(self.database_url)
-            cursor = conn.cursor()
-            cursor.execute(
+            conn = duckdb.connect(self.db_path)
+            row = conn.execute(
                 """
                 SELECT exchange_rate FROM currency_rates
-                WHERE from_currency = %s AND to_currency = %s AND rate_date = %s
+                WHERE from_currency = ? AND to_currency = ? AND rate_date = ?
                 """,
                 (from_currency, to_currency, target_date.strftime("%Y-%m-%d")),
-            )
-            row = cursor.fetchone()
+            ).fetchone()
             return float(row[0]) if row else None
-        except psycopg2.Error as e:
+        except duckdb.Error as e:
             logger.error(f"Error getting cached exchange rate: {e}")
             return None
         finally:
-            if conn and not conn.closed:
+            if conn is not None:
                 conn.close()
     
     def get_exchange_rate(self, from_currency: str, to_currency: str = 'EUR', 

--- a/dbt/models/staging/sources.yml
+++ b/dbt/models/staging/sources.yml
@@ -5,7 +5,7 @@ sources:
     description: >
       Raw tables written by the Python ETL pipeline (analytics/etl/).
       These are the system-of-record tables that dbt reads but never writes to.
-    schema: public
+    schema: main
 
     # Source freshness: warn if etf_data hasn't received new rows in 12 h,
     # error if not updated in 24 h. Checked by `dbt source freshness`.

--- a/dbt/profiles.yml
+++ b/dbt/profiles.yml
@@ -1,14 +1,10 @@
 etf_analytics:
   outputs:
     dev:
-      type: postgres
-      host: "{{ env_var('DB_HOST', 'localhost') }}"
-      port: "{{ env_var('DB_PORT', '5432') | int }}"
-      user: "{{ env_var('DB_USER', 'etf_user') }}"
-      password: "{{ env_var('DB_PASSWORD', 'etf_pass') }}"
-      dbname: "{{ env_var('DB_NAME', 'etf_db') }}"
-      schema: public
+      type: duckdb
+      # Same file the Python ETL writes to. dbt runs from the `dbt/` dir, so the
+      # default resolves to `warehouse.duckdb` at the repo root. Set DUCKDB_PATH
+      # to an absolute path to override (keep it consistent with the ETL).
+      path: "{{ env_var('DUCKDB_PATH', '../warehouse.duckdb') }}"
       threads: 4
-      # require SSL for hosted DBs (Supabase/Neon); 'prefer' works for local Docker
-      sslmode: "{{ env_var('DB_SSLMODE', 'prefer') }}"
   target: dev

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,12 +4,12 @@ yfinance>=0.2.36
 python-dotenv>=1.0.0
 schedule>=1.2.0
 
-# PostgreSQL driver
-psycopg2-binary>=2.9.9
+# Embedded analytical database (single-file warehouse)
+duckdb>=1.0.0
 
 # dbt
 dbt-core>=1.8.0
-dbt-postgres>=1.8.0
+dbt-duckdb>=1.8.0
 
 # Data visualization (legacy / optional)
 matplotlib>=3.7.0


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements **Phase 1 — dbt on DuckDB only** from `analytics/docs/stock-market-v2-reporting-layer.md`, including the ETL write-path migration (agreed scope, since dropping `psycopg2` otherwise breaks extract/load).

## Changes
- **Dependencies** (`requirements.txt`): replaced `psycopg2-binary` + `dbt-postgres` with `duckdb` + `dbt-duckdb`.
- **Schema** (`analytics/database/schema.sql`): DuckDB dialect — sequences instead of `SERIAL`, and `DOUBLE` instead of `DECIMAL` for numeric columns. Using `DOUBLE` returns native Python floats, which **fixes the pre-existing `Decimal * float` 52-week-metrics bug**.
- **ETL writer** (`db_manager.py`, `utils/currency_converter.py`): rewritten for the DuckDB Python API (`?` placeholders, `duckdb.connect`). `insert_market_data` now performs currency conversion *before* opening the writer connection, because DuckDB permits only one read-write connection to a file at a time.
- **dbt** (`profiles.yml`): single `duckdb` target; `sources.yml` schema `public` → `main`. Models needed no SQL changes (`distinct on`, window funcs, `round`, `coalesce` are DuckDB-compatible).
- **Config**: `.env.example` rewritten for `DUCKDB_PATH`; `.gitignore` ignores `*.duckdb`; `init_db.py` docstring updated.
- **AGENTS.md**: updated for the DuckDB (no-server) setup.

## Path convention
ETL runs from repo root (`./warehouse.duckdb`); dbt runs from `dbt/` (`../warehouse.duckdb`) — both resolve to the same repo-root file. Override with an absolute `DUCKDB_PATH`.

## Verification (fresh DuckDB build)
- ✅ `analytics/enhanced_workflow.py --step full` — 5/5 symbols, metrics stored (bug fixed)
- ✅ `dbt run --profiles-dir .` — 6 models built
- ✅ `dbt test --profiles-dir .` — 41/41 pass
- ✅ Marts populated: `mart_price_history`=5766, `mart_52week_metrics`=5, **`mart_entry_thresholds`=30** (previously 0)
- ✅ `analytics/test_enhanced_workflow.py` — 4/4 (no DB server needed)
- ✅ `analytics/enhanced_workflow.py --step incremental` — idempotent re-run OK
- ✅ `analytics/database_diagnostic.py` — runs clean
- ✅ Update script (`pip install`) resolves cleanly (`pip check` OK)

## Deferred (Phase 2, as agreed)
`production_automation.yml` and `test_automation.yml` still reference PostgreSQL and will be inconsistent with the DuckDB pipeline until Phase 2 rewrites them. Flagging so the nightly production workflow is understood to need Phase 2 before it's healthy again.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3246e54d-4292-4a4c-ad02-8fdd24bbc28e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3246e54d-4292-4a4c-ad02-8fdd24bbc28e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

