### PR TITLE
Dashboard mockup-parity redesign + rebrand to imbuto

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# ETF Analytics — End-to-End Data Engineering Pipeline
+# imbuto
 
-A cost-free, fully cloud-run Data Engineering project tracking 5 ETFs (VOO, VTI, QQQ, VUAA.L, CNDX.L).
-It runs a complete **ELT** pipeline — from raw market data to a public dashboard — with no database
-server and no local machine involvement.
+A cost-free, fully cloud-run **ETF Analytics** Data Engineering project tracking 5 ETFs
+(VOO, VTI, QQQ, VUAA.L, CNDX.L). It runs a complete **ELT** pipeline — from raw market data to a
+public dashboard — with no database server and no local machine involvement.
 
-> **Live dashboard:** _add your Streamlit Community Cloud URL here_
+> **Live dashboard:** https://imbuto.streamlit.app/
 >
 > **Design & roadmap:** [`analytics/docs/stock-market-v2-reporting-layer.md`](analytics/docs/stock-market-v2-reporting-layer.md) is the single source of truth for the architecture direction.
 
@@ -139,7 +139,7 @@ After a one-time Streamlit Cloud deploy, the dashboard refreshes daily on its ow
 ## Project Structure
 
 ```
-stock-market/
+imbuto/
 ├── analytics/
 │   ├── enhanced_workflow.py        ETL orchestrator (used by GitHub Actions)
 │   ├── database/                   schema (DuckDB), DB manager, symbol loader, init

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -1,19 +1,22 @@
 """
-ETF Analytics Dashboard (Streamlit)
+ETF Analytics Dashboard (Streamlit) — "imbuto"
 
 Reads the DuckDB warehouse produced by the pipeline (mart_price_history,
-mart_52week_metrics, mart_entry_thresholds) and renders the dashboard from
-analytics/docs/assets/etf-dashboard-mockup.png.
+mart_52week_metrics, mart_entry_thresholds, mart_fx_rates) and renders the
+dashboard from analytics/docs/assets/etf-dashboard-mockup.png.
 
 Data source resolution (first match wins):
   1. $DUCKDB_PATH (if the file exists)
   2. a local warehouse.duckdb in the repo (dev convenience)
   3. the published GitHub Release asset ($WAREHOUSE_URL, tag `latest-data`)
+
+Currency: values are converted via EUR as a pivot (triangulation) so any of
+EUR / USD / GBP can be displayed for every ETF.
 """
 
 import os
 import tempfile
-from datetime import datetime
+from datetime import timedelta
 
 import duckdb
 import pandas as pd
@@ -26,11 +29,10 @@ import streamlit as st
 # ---------------------------------------------------------------------------
 RELEASE_URL = os.environ.get(
     "WAREHOUSE_URL",
-    "https://github.com/anyarlene/stock-market/releases/download/latest-data/warehouse.duckdb",
+    "https://github.com/anyarlene/imbuto/releases/download/latest-data/warehouse.duckdb",
 )
 DATA_TTL = 6 * 3600  # refresh cached data every 6h (pipeline runs daily)
 
-# Per-ETF display order and accent colors (matches the mockup)
 ORDER = ["VOO", "VTI", "QQQ", "VUAA.L", "CNDX.L"]
 COLORS = {
     "VOO": "#3b82f6",
@@ -40,9 +42,9 @@ COLORS = {
     "CNDX.L": "#ef4444",
 }
 CURRENCY_SYMBOL = {"USD": "$", "GBP": "£", "EUR": "€"}
+CURRENCIES = ["EUR", "USD", "GBP"]
 UP = "#22c55e"
 DOWN = "#ef4444"
-
 RANGE_DAYS = {"1M": 30, "3M": 91, "1Y": 365, "2Y": 730, "ALL": None}
 
 st.set_page_config(page_title="ETF Analytics Dashboard", page_icon="📈", layout="wide")
@@ -66,12 +68,11 @@ def _resolve_db_path() -> str:
     if env_path and os.path.exists(env_path):
         return env_path
     here = os.path.dirname(os.path.abspath(__file__))
-    candidates = [
+    for cand in [
         os.path.join(here, "..", "warehouse.duckdb"),
         os.path.join(os.getcwd(), "warehouse.duckdb"),
         "warehouse.duckdb",
-    ]
-    for cand in candidates:
+    ]:
         if os.path.exists(cand):
             return cand
     return _download_warehouse(RELEASE_URL)
@@ -79,20 +80,43 @@ def _resolve_db_path() -> str:
 
 @st.cache_data(ttl=DATA_TTL)
 def load_data():
-    path = _resolve_db_path()
-    con = duckdb.connect(path, read_only=True)
+    con = duckdb.connect(_resolve_db_path(), read_only=True)
     try:
         price = con.execute("SELECT * FROM mart_price_history").df()
         metrics = con.execute("SELECT * FROM mart_52week_metrics").df()
         thresholds = con.execute("SELECT * FROM mart_entry_thresholds").df()
+        fx = con.execute("SELECT * FROM mart_fx_rates").df()
     finally:
         con.close()
     price["date"] = pd.to_datetime(price["date"])
-    return price, metrics, thresholds
+    return price, metrics, thresholds, fx
 
 
-def fmt_price(value, currency) -> str:
-    sym = CURRENCY_SYMBOL.get(currency, "")
+# ---------------------------------------------------------------------------
+# Currency conversion (EUR pivot / triangulation)
+# ---------------------------------------------------------------------------
+def build_rate_to_eur(fx: pd.DataFrame) -> dict:
+    """Latest <ccy>→EUR rate per source currency, plus EUR→EUR = 1."""
+    rates = {"EUR": 1.0}
+    if not fx.empty:
+        latest = fx.sort_values("rate_date").groupby("from_currency").tail(1)
+        for _, r in latest.iterrows():
+            rates[r["from_currency"]] = float(r["exchange_rate"])
+    return rates
+
+
+def convert(value, src_ccy, tgt_ccy, rate_to_eur) -> float:
+    """Convert a scalar from src_ccy to tgt_ccy via EUR."""
+    if value is None or pd.isna(value):
+        return None
+    if src_ccy not in rate_to_eur or tgt_ccy not in rate_to_eur:
+        return float(value)
+    value_eur = float(value) * rate_to_eur[src_ccy]
+    return value_eur / rate_to_eur[tgt_ccy]
+
+
+def fmt(value, ccy) -> str:
+    sym = CURRENCY_SYMBOL.get(ccy, "")
     if value is None or pd.isna(value):
         return "—"
     return f"{sym}{value:,.2f}"
@@ -104,15 +128,19 @@ def fmt_price(value, currency) -> str:
 st.markdown(
     """
     <style>
-      .block-container {padding-top: 1.5rem; padding-bottom: 2rem; max-width: 1400px;}
-      .app-title {font-size: 1.8rem; font-weight: 800; margin: 0;}
-      .app-sub {color: #94a3b8; font-size: 0.95rem; margin-top: -2px;}
-      .app-meta {color: #94a3b8; font-size: 0.85rem; text-align: right;}
+      div[data-testid="stMainBlockContainer"], .block-container {
+        padding-top: 4.5rem !important; padding-bottom: 2rem; max-width: 1500px;
+      }
+      #MainMenu, footer {visibility: hidden;}
+      .app-header {line-height: 1.25;}
+      .app-title {font-size: 1.9rem; font-weight: 800;}
+      .app-sub {color: #94a3b8; font-size: 0.95rem;}
+      .app-meta {color: #94a3b8; font-size: 0.85rem; text-align: right; margin-top: 6px;}
       .kpi-ticker {font-size: 1.15rem; font-weight: 800;}
       .kpi-name {color: #94a3b8; font-size: 0.8rem; min-height: 2.2em; line-height: 1.1em;}
       .kpi-price {font-size: 1.7rem; font-weight: 800; margin-top: 4px;}
       .kpi-change {font-size: 0.95rem; font-weight: 700;}
-      .panel-title {font-size: 1.15rem; font-weight: 700; margin-bottom: 0.4rem;}
+      .panel-title {font-size: 1.15rem; font-weight: 700; margin-bottom: 0.2rem;}
       table.summary {width: 100%; border-collapse: collapse; font-size: 0.9rem;}
       table.summary th {color: #94a3b8; text-align: right; padding: 8px 10px; font-weight: 600;
                         border-bottom: 1px solid #1f2a44;}
@@ -129,7 +157,7 @@ st.markdown(
 # Load
 # ---------------------------------------------------------------------------
 try:
-    price_df, metrics_df, thresholds_df = load_data()
+    price_df, metrics_df, thresholds_df, fx_df = load_data()
 except Exception as exc:  # pragma: no cover - surfaced in the UI
     st.error(
         "Could not load the DuckDB warehouse. Ensure the pipeline has published "
@@ -139,7 +167,11 @@ except Exception as exc:  # pragma: no cover - surfaced in the UI
 
 tickers = [t for t in ORDER if t in set(price_df["ticker"])]
 metrics_by_ticker = {r["ticker"]: r for _, r in metrics_df.iterrows()}
+native_ccy = {t: metrics_by_ticker[t]["native_currency"] for t in tickers if t in metrics_by_ticker}
+rate_to_eur = build_rate_to_eur(fx_df)
 last_updated = pd.to_datetime(price_df["date"]).max()
+data_min = pd.to_datetime(price_df["date"]).min().date()
+data_max = last_updated.date()
 
 
 # ---------------------------------------------------------------------------
@@ -147,141 +179,180 @@ last_updated = pd.to_datetime(price_df["date"]).max()
 # ---------------------------------------------------------------------------
 h_left, h_right = st.columns([3, 1])
 with h_left:
-    st.markdown('<p class="app-title">📈 ETF Analytics Dashboard</p>', unsafe_allow_html=True)
-    st.markdown('<p class="app-sub">Performance overview and entry point analysis</p>', unsafe_allow_html=True)
-with h_right:
     st.markdown(
-        f'<p class="app-meta">Last updated<br><b>{last_updated:%b %d, %Y}</b></p>',
+        '<div class="app-header">'
+        '<span class="app-title">📈 ETF Analytics Dashboard</span><br>'
+        '<span class="app-sub">ETF performance overview &amp; entry-point analysis</span>'
+        "</div>",
         unsafe_allow_html=True,
     )
+with h_right:
+    st.markdown(f'<div class="app-meta">Last updated: {last_updated:%b %d, %Y}</div>', unsafe_allow_html=True)
+    if st.button("🔄 Refresh data", use_container_width=True):
+        st.cache_data.clear()
+        st.rerun()
 
 
 # ---------------------------------------------------------------------------
-# KPI cards
+# Global controls
+# ---------------------------------------------------------------------------
+c1, c2, c3 = st.columns([2, 1, 2])
+with c1:
+    focus = st.selectbox("ETF", tickers, index=tickers.index("VOO") if "VOO" in tickers else 0)
+with c2:
+    currency = st.selectbox("Currency", CURRENCIES, index=CURRENCIES.index("EUR"))
+with c3:
+    compare_all = st.toggle("Compare all ETFs (normalized)", value=False)
+
+sym = CURRENCY_SYMBOL.get(currency, "")
+
+
+# ---------------------------------------------------------------------------
+# KPI cards (all ETFs, in the selected currency)
 # ---------------------------------------------------------------------------
 kpi_cols = st.columns(len(tickers))
 for col, tk in zip(kpi_cols, tickers):
     sub = price_df[price_df["ticker"] == tk].sort_values("date")
     last = sub.iloc[-1]
-    m = metrics_by_ticker.get(tk, {})
-    currency = last["native_currency"]
     change = last["daily_change_pct"]
     up = bool(change is not None and not pd.isna(change) and change >= 0)
     trend_color = UP if up else DOWN
-    spark = sub["close"].tail(30).tolist()
+    # convert EUR series to the selected currency (uniform scale)
+    price_val = convert(last["close_eur"], "EUR", currency, rate_to_eur)
+    spark = (sub["close_eur"] / rate_to_eur.get(currency, 1.0)).tail(30).tolist()
 
     with col:
         with st.container(border=True):
             st.markdown(
                 f'<div class="kpi-ticker" style="color:{COLORS.get(tk,"#fff")}">{tk}</div>'
-                f'<div class="kpi-name">{m.get("etf_name","")}</div>'
-                f'<div class="kpi-price">{fmt_price(last["close"], currency)}</div>'
+                f'<div class="kpi-name">{metrics_by_ticker.get(tk, {}).get("etf_name","")}</div>'
+                f'<div class="kpi-price">{fmt(price_val, currency)}</div>'
                 f'<div class="kpi-change" style="color:{trend_color}">'
                 f'{"▲" if up else "▼"} {change:+.2f}%</div>',
                 unsafe_allow_html=True,
             )
             spark_fig = go.Figure(go.Scatter(y=spark, mode="lines", line=dict(color=trend_color, width=2)))
             spark_fig.update_layout(
-                height=52,
-                margin=dict(l=0, r=0, t=6, b=0),
-                xaxis=dict(visible=False),
-                yaxis=dict(visible=False),
-                paper_bgcolor="rgba(0,0,0,0)",
-                plot_bgcolor="rgba(0,0,0,0)",
-                showlegend=False,
+                height=52, margin=dict(l=0, r=0, t=6, b=0),
+                xaxis=dict(visible=False), yaxis=dict(visible=False),
+                paper_bgcolor="rgba(0,0,0,0)", plot_bgcolor="rgba(0,0,0,0)", showlegend=False,
             )
             st.plotly_chart(spark_fig, use_container_width=True, config={"displayModeBar": False})
 
 
 # ---------------------------------------------------------------------------
-# Price history (normalized to 100 at the start of the selected range)
+# Price history
 # ---------------------------------------------------------------------------
 st.markdown("")
-ph_left, ph_right = st.columns([2, 3])
-with ph_left:
+title_col, pills_col, cal_col = st.columns([2, 2, 1])
+with title_col:
     st.markdown('<p class="panel-title">Price History</p>', unsafe_allow_html=True)
-with ph_right:
-    selected_range = st.radio(
-        "Range", list(RANGE_DAYS.keys()), index=2, horizontal=True, label_visibility="collapsed"
+with pills_col:
+    selected_range = st.segmented_control(
+        "Range", list(RANGE_DAYS.keys()), default="1Y", label_visibility="collapsed"
     )
+with cal_col:
+    with st.popover("📅 Dates", use_container_width=True):
+        custom = st.date_input(
+            "Custom range",
+            value=(),
+            min_value=data_min,
+            max_value=data_max,
+            format="YYYY-MM-DD",
+        )
 
-days = RANGE_DAYS[selected_range]
-if days is not None:
-    cutoff = last_updated - pd.Timedelta(days=days)
-    ranged = price_df[price_df["date"] >= cutoff]
+# Resolve the active window: a custom date range overrides the pills.
+start_date = end_date = None
+if isinstance(custom, (list, tuple)) and len(custom) == 2:
+    start_date = pd.Timestamp(custom[0])
+    end_date = pd.Timestamp(custom[1])
 else:
-    ranged = price_df
+    days = RANGE_DAYS.get(selected_range or "1Y")
+    end_date = last_updated
+    start_date = (last_updated - pd.Timedelta(days=days)) if days else None
+
+mask = price_df["date"] <= end_date
+if start_date is not None:
+    mask &= price_df["date"] >= start_date
+ranged = price_df[mask]
 
 fig = go.Figure()
-for tk in tickers:
-    s = ranged[ranged["ticker"] == tk].sort_values("date")
-    if s.empty:
-        continue
-    base = s["close"].iloc[0]
-    indexed = s["close"] / base * 100.0
+if compare_all:
+    for tk in tickers:
+        s = ranged[ranged["ticker"] == tk].sort_values("date")
+        if s.empty:
+            continue
+        base = s["close_eur"].iloc[0]
+        fig.add_trace(
+            go.Scatter(
+                x=s["date"], y=s["close_eur"] / base * 100.0, mode="lines", name=tk,
+                line=dict(color=COLORS.get(tk), width=2),
+                hovertemplate=f"<b>{tk}</b> %{{x|%b %d, %Y}}<br>%{{y:.1f}}%<extra></extra>",
+            )
+        )
+    y_title = "Indexed to 100 at range start"
+else:
+    s = ranged[ranged["ticker"] == focus].sort_values("date")
+    conv = 1.0 / rate_to_eur.get(currency, 1.0)
+    series = s["close_eur"] * conv
     fig.add_trace(
         go.Scatter(
-            x=s["date"],
-            y=indexed,
-            mode="lines",
-            name=tk,
-            line=dict(color=COLORS.get(tk), width=2),
-            hovertemplate=f"<b>{tk}</b> %{{x|%b %d, %Y}}<br>%{{y:.1f}}%<extra></extra>",
+            x=s["date"], y=series, mode="lines", name=focus,
+            line=dict(color=COLORS.get(focus), width=2.2),
+            hovertemplate=f"<b>{focus}</b> %{{x|%b %d, %Y}}<br>{sym}%{{y:,.2f}}<extra></extra>",
         )
     )
+    # 52-week high/low (same source as the summary table) in the selected currency
+    fm = metrics_by_ticker.get(focus)
+    if fm is not None and pd.notna(fm["high_52week"]):
+        src = fm["native_currency"]
+        hi = convert(fm["high_52week"], src, currency, rate_to_eur)
+        lo = convert(fm["low_52week"], src, currency, rate_to_eur)
+        fig.add_hline(y=hi, line=dict(color=UP, width=1.3, dash="dash"),
+                      annotation_text=f"52W High {fmt(hi, currency)}", annotation_position="top left")
+        fig.add_hline(y=lo, line=dict(color=DOWN, width=1.3, dash="dash"),
+                      annotation_text=f"52W Low {fmt(lo, currency)}", annotation_position="bottom left")
+    y_title = f"Price ({currency})"
+
 fig.update_layout(
-    template="plotly_dark",
-    height=420,
-    margin=dict(l=10, r=10, t=10, b=10),
-    paper_bgcolor="rgba(0,0,0,0)",
-    plot_bgcolor="rgba(0,0,0,0)",
+    template="plotly_dark", height=430, margin=dict(l=10, r=10, t=10, b=10),
+    paper_bgcolor="rgba(0,0,0,0)", plot_bgcolor="rgba(0,0,0,0)",
     legend=dict(orientation="h", yanchor="bottom", y=1.02, x=0),
-    yaxis=dict(title="Indexed to 100 at range start", ticksuffix="%", gridcolor="#1f2a44"),
+    yaxis=dict(title=y_title, gridcolor="#1f2a44", ticksuffix="%" if compare_all else ""),
     xaxis=dict(gridcolor="#131c30"),
 )
 st.plotly_chart(fig, use_container_width=True, config={"displayModeBar": False})
 
 
 # ---------------------------------------------------------------------------
-# Entry thresholds + 52-week summary
+# Entry thresholds (selected ETF) + 52-week summary
 # ---------------------------------------------------------------------------
 left, right = st.columns([1, 1])
 
 with left:
-    st.markdown('<p class="panel-title">Entry Point Thresholds (Below 52-Week High)</p>', unsafe_allow_html=True)
-    sel = st.selectbox("ETF", tickers, index=tickers.index("VOO") if "VOO" in tickers else 0)
-    t = thresholds_df[thresholds_df["ticker"] == sel].sort_values("pct_below")
+    st.markdown(f'<p class="panel-title">Entry Point Thresholds — {focus} (Below 52-Week High)</p>', unsafe_allow_html=True)
+    t = thresholds_df[thresholds_df["ticker"] == focus].sort_values("pct_below")
     if t.empty:
         st.info("No threshold data for this ETF.")
     else:
-        currency = t["native_currency"].iloc[0]
-        current = float(t["latest_close"].iloc[0])
+        src = t["native_currency"].iloc[0]
+        current = convert(float(t["latest_close"].iloc[0]), src, currency, rate_to_eur)
         labels = [f"{int(p)}% Below High" for p in t["pct_below"]]
-        prices = t["threshold_price"].astype(float).tolist()
-        bar = go.Figure()
-        bar.add_trace(
+        prices = [convert(float(p), src, currency, rate_to_eur) for p in t["threshold_price"]]
+        bar = go.Figure(
             go.Bar(
-                x=prices,
-                y=labels,
-                orientation="h",
-                marker_color="#3b82f6",
-                text=[fmt_price(p, currency) for p in prices],
-                textposition="outside",
-                hovertemplate="%{y}: %{x:.2f}<extra></extra>",
+                x=prices, y=labels, orientation="h", marker_color="#3b82f6",
+                text=[fmt(p, currency) for p in prices], textposition="outside",
+                hovertemplate="%{y}: %{x:,.2f}<extra></extra>",
             )
         )
         bar.add_vline(
-            x=current,
-            line=dict(color="#e5e7eb", width=1.5, dash="dash"),
-            annotation_text=f"Current {fmt_price(current, currency)}",
-            annotation_position="top",
+            x=current, line=dict(color="#e5e7eb", width=1.5, dash="dash"),
+            annotation_text=f"Current {fmt(current, currency)}", annotation_position="top",
         )
         bar.update_layout(
-            template="plotly_dark",
-            height=360,
-            margin=dict(l=10, r=40, t=20, b=10),
-            paper_bgcolor="rgba(0,0,0,0)",
-            plot_bgcolor="rgba(0,0,0,0)",
+            template="plotly_dark", height=360, margin=dict(l=10, r=50, t=20, b=10),
+            paper_bgcolor="rgba(0,0,0,0)", plot_bgcolor="rgba(0,0,0,0)",
             xaxis=dict(title=f"Price ({currency})", gridcolor="#1f2a44"),
             yaxis=dict(autorange="reversed"),
         )
@@ -292,22 +363,24 @@ with right:
     rows_html = [
         "<table class='summary'>",
         "<tr><th class='left'>Ticker</th><th class='left'>ETF Name</th>"
-        "<th>52-Week High</th><th>52-Week Low</th><th>Current Price</th><th>Distance from High</th></tr>",
+        f"<th>52-Week High ({currency})</th><th>52-Week Low ({currency})</th>"
+        f"<th>Current ({currency})</th><th>Distance from High</th></tr>",
     ]
     for tk in tickers:
         m = metrics_by_ticker.get(tk)
         if m is None:
             continue
-        cur = m["native_currency"]
+        src = m["native_currency"]
+        hi = convert(m["high_52week"], src, currency, rate_to_eur)
+        lo = convert(m["low_52week"], src, currency, rate_to_eur)
+        cur = convert(m["latest_close"], src, currency, rate_to_eur)
         distance = -float(m["pct_below_52w_high"]) if pd.notna(m["pct_below_52w_high"]) else 0.0
         dcolor = DOWN if distance < 0 else UP
         rows_html.append(
             "<tr>"
             f"<td class='left'><span class='dot' style='background:{COLORS.get(tk)}'></span><b>{tk}</b></td>"
             f"<td class='left'>{m['etf_name']}</td>"
-            f"<td>{fmt_price(m['high_52week'], cur)}</td>"
-            f"<td>{fmt_price(m['low_52week'], cur)}</td>"
-            f"<td>{fmt_price(m['latest_close'], cur)}</td>"
+            f"<td>{fmt(hi, currency)}</td><td>{fmt(lo, currency)}</td><td>{fmt(cur, currency)}</td>"
             f"<td style='color:{dcolor}'>{distance:+.2f}%</td>"
             "</tr>"
         )
@@ -320,6 +393,6 @@ with right:
 # ---------------------------------------------------------------------------
 st.markdown("")
 st.caption(
-    "Prices shown in each ETF's native currency. Data built by the automated DuckDB "
-    f"pipeline · Data as of {last_updated:%b %d, %Y}"
+    f"Values shown in {currency}. Cross-currency figures use EUR as a pivot (latest FX rate). "
+    f"Data as of {last_updated:%b %d, %Y}."
 )

--- a/dashboard/requirements.txt
+++ b/dashboard/requirements.txt
@@ -1,5 +1,5 @@
 # Streamlit Community Cloud dependencies for the ETF Analytics dashboard.
-streamlit>=1.36
+streamlit>=1.40
 duckdb>=1.0.0
 plotly>=5.18
 pandas>=1.5.0

--- a/dbt/models/marts/mart_fx_rates.sql
+++ b/dbt/models/marts/mart_fx_rates.sql
@@ -1,0 +1,15 @@
+/*
+  mart_fx_rates
+  -------------
+  Historical FX rates to EUR (USD→EUR, GBP→EUR), exposed for the dashboard's
+  currency conversion. The app uses EUR as a pivot to display values in EUR,
+  USD, or GBP (triangulation, e.g. USD→GBP = (USD→EUR) / (GBP→EUR)).
+*/
+
+select
+    from_currency,
+    to_currency,
+    rate_date,
+    exchange_rate
+from {{ ref('stg_currency_rates') }}
+where to_currency = 'EUR'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "stock-market"
+name = "imbuto"
 version = "0.1.0"
 description = "ETF analytics and visualization tool"
 readme = "README.md"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Brings the Streamlit dashboard closer to `analytics/docs/assets/etf-dashboard-mockup.png` and rebrands the project to **imbuto**.

## Dashboard (`dashboard/app.py`)
- **Fixed header**: bold "📈 ETF Analytics Dashboard" + subtitle + top-right "Last updated" and a working "🔄 Refresh data" button. (Root cause of the earlier "missing title" was the first header line being clipped under Streamlit's top toolbar — fixed with proper top padding, and the header is rendered as a single HTML block.)
- **Shared ETF filter** driving both the Price History chart and the Entry Point Thresholds chart/table.
- **"Compare all (normalized)" toggle**: off → single ETF actual price with dashed **52W High/Low** lines; on → 5 ETFs normalized to 100%.
- **Currency selector EUR/USD/GBP** (EUR default) via EUR-pivot triangulation, applied to KPI cards, chart, thresholds, and summary table.
- **Range pills** (`st.segmented_control`) + a **📅 calendar** date-range popover that overrides the pills.
- 52W High/Low lines use the same source as the summary table (`mart_52week_metrics`) so they always match.

## dbt
- New `mart_fx_rates` model exposing `USD→EUR` / `GBP→EUR` rates for the app's currency conversion.

## Rebrand → imbuto
- `README.md` H1 → **imbuto**, live dashboard link → https://imbuto.streamlit.app/.
- `pyproject.toml` package name → `imbuto`.
- App `WAREHOUSE_URL` default → `…/anyarlene/imbuto/releases/download/latest-data/warehouse.duckdb`.
- `dashboard/requirements.txt` → `streamlit>=1.40` (needed for `st.segmented_control`).

## Functional checks (no video, per request)
- ✅ ETF switch (VOO→QQQ) updates the price line + 52W values and the thresholds panel
- ✅ Currency EUR→USD updates KPI cards, chart axis/labels, table headers
- ✅ Compare toggle switches between single-line+52W and 5 normalized lines
- ✅ Range pills rescale; 📅 date popover opens
- ✅ Verified currency math is consistent (e.g. QQQ 52W-high €655.17 > current €619.55; KPI == table)

## Action required (you)
Rename the GitHub repo **`stock-market` → `imbuto`** (Settings → rename) so the `WAREHOUSE_URL` resolves under the new slug. GitHub auto-redirects the old URL during the transition, so nothing breaks in the meantime.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3246e54d-4292-4a4c-ad02-8fdd24bbc28e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3246e54d-4292-4a4c-ad02-8fdd24bbc28e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

